### PR TITLE
0.3.0 Zone fix, adjust loot config & update render config, keep team at start

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ mapping_version=1.20.1
 mod_id=battleroyale
 mod_name=Custom BattleRoyale
 mod_license=GPL-3.0 license
-mod_version=0.2.9
+mod_version=0.3.0
 mod_group_id=xiao.battleroyale
 mod_authors=XiaoColorful

--- a/src/main/java/xiao/battleroyale/api/IConfigDefaultable.java
+++ b/src/main/java/xiao/battleroyale/api/IConfigDefaultable.java
@@ -5,13 +5,12 @@ import org.jetbrains.annotations.Nullable;
 public interface IConfigDefaultable<T> {
 
     void generateDefaultConfigs();
-
-    void generateDefaultConfigs(int configType);
+    void generateDefaultConfigs(int folderId);
 
     int getDefaultConfigId();
-    int getDefaultConfigId(int configType);
+    int getDefaultConfigId(int folderId);
     void setDefaultConfigId(int id);
-    void setDefaultConfigId(int id, int configType);
+    void setDefaultConfigId(int id, int folderId);
     @Nullable T getDefaultConfig();
-    @Nullable T getDefaultConfig(int configType);
+    @Nullable T getDefaultConfig(int folderId);
 }

--- a/src/main/java/xiao/battleroyale/api/IConfigLoadable.java
+++ b/src/main/java/xiao/battleroyale/api/IConfigLoadable.java
@@ -9,36 +9,36 @@ import java.util.Set;
 public interface IConfigLoadable<T> {
 
     Set<String> getAvailableConfigFileNames();
-    Set<String> getAvailableConfigFileNames(int configType);
+    Set<String> getAvailableConfigFileNames(int folderId);
 
     /**
      * 执行一次只重新读取一次
      */
     boolean reloadConfigs();
-    boolean reloadConfigs(int configType);
+    boolean reloadConfigs(int folderId);
 
     @Nullable
     T parseConfigEntry(JsonObject jsonObject, Path filePath);
     @Nullable
-    T parseConfigEntry(JsonObject jsonObject, Path filePath, int configType);
+    T parseConfigEntry(JsonObject jsonObject, Path filePath, int folderId);
 
     /**
      * 是否已经读取到数据，不一定已经选中
      */
     boolean hasConfigLoaded();
-    boolean hasConfigLoaded(int configType);
+    boolean hasConfigLoaded(int folderId);
 
     /**
      * 仅当文件夹下无有效配置文件时写入默认配置
      * 写入后不自动重新读取
      */
     void initializeDefaultConfigsIfEmpty();
-    void initializeDefaultConfigsIfEmpty(int configType);
+    void initializeDefaultConfigsIfEmpty(int folderId);
 
     String getConfigPath();
-    String getConfigPath(int configType);
+    String getConfigPath(int folderId);
     String getConfigSubPath();
-    String getConfigSubPath(int configType);
+    String getConfigSubPath(int folderId);
     Path getConfigDirPath();
-    Path getConfigDirPath(int configType);
+    Path getConfigDirPath(int folderId);
 }

--- a/src/main/java/xiao/battleroyale/api/IConfigManager.java
+++ b/src/main/java/xiao/battleroyale/api/IConfigManager.java
@@ -10,12 +10,12 @@ public interface IConfigManager<T> extends IConfigSwitchable, IConfigLoadable<T>
      * 获取当前配置
      */
     @Nullable T getConfigEntry(int id);
-    @Nullable T getConfigEntry(int id, int configType);
+    @Nullable T getConfigEntry(int id, int folderId);
     List<T> getConfigEntryList();
-    List<T> getConfigEntryList(int configType);
+    List<T> getConfigEntryList(int folderId);
     String getConfigEntryFileName();
-    String getConfigEntryFileName(int configType);
+    String getConfigEntryFileName(int folderId);
 
     String getFolderType();
-    String getFolderType(int configType);
+    String getFolderType(int folderId);
 }

--- a/src/main/java/xiao/battleroyale/api/client/render/RenderConfigTag.java
+++ b/src/main/java/xiao/battleroyale/api/client/render/RenderConfigTag.java
@@ -6,6 +6,7 @@ public class RenderConfigTag extends ConfigEntryTag {
 
     public static String BLOCK_ENTRY = "block";
     public static String ZONE_ENTRY = "zone";
+    public static String TEAM_ENTRY = "teamEntry";
 
     public static String ITEM_RENDER_DISTANCE = "itemRenderDistance";
 
@@ -15,6 +16,11 @@ public class RenderConfigTag extends ConfigEntryTag {
     public static String ELLIPSE_SEGMENTS = "ellipseSegments";
     public static String SPHERE_SEGMENTS = "sphereSegments";
     public static String ELLIPSOID_SEGMENTS = "ellispoidSegments";
+
+    public static String ENABLE_TEAM_ZONE = "enableTeamZone";
+    public static String RENDER_BEACON = "renderBeacon";
+    public static String RENDER_BOUNDING_BOX = "renderBoundingBox";
+    public static String TRANSPARENCY = "transparency";
     
     private RenderConfigTag() {}
 }

--- a/src/main/java/xiao/battleroyale/api/minecraft/EquipmentLevel.java
+++ b/src/main/java/xiao/battleroyale/api/minecraft/EquipmentLevel.java
@@ -87,4 +87,10 @@ public class EquipmentLevel {
         int damage = Math.max(getDamage(material, part) - 2 * shootTaken, 0);
         return new ItemEntry(equipName, "{Damage:" + damage + "}", 1);
     }
+
+    public static ItemEntry equipment(int material, int part, int shootTaken, int enchantment) {
+        String equipName = getName(material, part);
+        int damage = Math.max(getDamage(material, part) - 2 * shootTaken, 0);
+        return new ItemEntry(equipName, String.format("{Damage:%d,Enchantments:[{id:\"minecraft:protection\",lvl:%d}]}", damage, enchantment), 1);
+    }
 }

--- a/src/main/java/xiao/battleroyale/client/game/data/ClientSingleZoneData.java
+++ b/src/main/java/xiao/battleroyale/client/game/data/ClientSingleZoneData.java
@@ -22,6 +22,10 @@ public class ClientSingleZoneData extends AbstractClientExpireData {
     public final int id;
     public String name;
     public Color color;
+    public float r = 1;
+    public float g = 1;
+    public float b = 1;
+    public float a = 1;
     public ZoneFuncType funcType;
     public ZoneShapeType shapeType;
     public Vec3 center;
@@ -46,6 +50,10 @@ public class ClientSingleZoneData extends AbstractClientExpireData {
         if (useClientColor) {
             this.color = ColorUtils.changeColorExceptAlpha(this.color, clientColorString);
         }
+        this.r = this.color.getRed() / 255.0F;
+        this.g = this.color.getGreen() / 255.0F;
+        this.b = this.color.getBlue() / 255.0F;
+        this.a = this.color.getAlpha() / 255.0F;
 
         String funcTypeName = nbt.getString(GameZoneTag.FUNC);
         this.funcType = ZoneFuncType.fromName(funcTypeName);

--- a/src/main/java/xiao/battleroyale/client/renderer/game/ZoneRenderer.java
+++ b/src/main/java/xiao/battleroyale/client/renderer/game/ZoneRenderer.java
@@ -108,10 +108,10 @@ public class ZoneRenderer {
 
                 VertexConsumer consumer = bufferSource.getBuffer(CUSTOM_ZONE_RENDER_TYPE);
 
-                float r = zoneData.color.getRed() / 255.0f;
-                float g = zoneData.color.getGreen() / 255.0f;
-                float b = zoneData.color.getBlue() / 255.0f;
-                float a = zoneData.color.getAlpha() / 255.0f;
+                float r = zoneData.r;
+                float g = zoneData.g;
+                float b = zoneData.b;
+                float a = zoneData.a;
 
                 switch (zoneData.shapeType) {
                     // 2D shape

--- a/src/main/java/xiao/battleroyale/common/game/loot/GameLootManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/loot/GameLootManager.java
@@ -229,7 +229,7 @@ public class GameLootManager extends AbstractGameManager {
      * 遍历存活玩家最后位置，BFS计算待处理区块（异步版本）
      */
     private void bfsQueuedChunkAsync() {
-        BattleRoyale.LOGGER.debug("Last BFS processed loot:{}", lastBfsProcessedLoot);
+        // BattleRoyale.LOGGER.debug("Last BFS processed loot:{}", lastBfsProcessedLoot);
         lastBfsProcessedLoot = 0;
 
         long startTime = System.nanoTime();
@@ -298,7 +298,7 @@ public class GameLootManager extends AbstractGameManager {
         long endTime = System.nanoTime();
         long durationMillis = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
 
-        BattleRoyale.LOGGER.debug("GameLootManager finished async BFS, added {} queued chunk in {}ms. Old queue size was {}.", newChunkQueue.size(), durationMillis, oldQueueSize);
+        // BattleRoyale.LOGGER.debug("GameLootManager finished async BFS, added {} queued chunk in {}ms. Old queue size was {}.", newChunkQueue.size(), durationMillis, oldQueueSize);
 
     }
 

--- a/src/main/java/xiao/battleroyale/common/game/team/GamePlayer.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/GamePlayer.java
@@ -5,6 +5,7 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 import xiao.battleroyale.BattleRoyale;
 import xiao.battleroyale.common.effect.EffectManager;
+import xiao.battleroyale.common.game.GameManager;
 
 import java.util.UUID;
 
@@ -36,6 +37,16 @@ public class GamePlayer {
         this.bot = isBot;
         this.team = team;
         this.invalidTime = 0;
+        reset();
+    }
+
+    public void reset() {
+        if (GameManager.get().isInGame()) {
+            BattleRoyale.LOGGER.debug("GameManager is in game, reject to reset GamePlayer {}, team {}", playerName, getGameTeamId());
+            return;
+        }
+        this.isAlive = true;
+        this.isEliminated = false;
     }
 
     public UUID getPlayerUUID() { return playerUUID; }
@@ -55,7 +66,7 @@ public class GamePlayer {
 
     public void setAlive(boolean alive) {
         this.isAlive = alive;
-        this.isEliminated = true; // TODO 倒地机制完成前默认淘汰
+        // TODO 倒地机制完成前默认淘汰
 
         if (team != null && team.isTeamEliminated()) { // 队伍无人则倒地
             this.isEliminated = true;

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamData.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamData.java
@@ -69,15 +69,27 @@ public class TeamData extends AbstractGameManagerData {
             return;
         }
 
-        if (maxPlayers <= this.maxPlayersLimit) {
-            return;
-        }
-
         this.maxPlayersLimit = maxPlayers;
         for (int i = this.maxPlayersLimit + 1; i <= maxPlayers; i++) {
             availablePlayerIds.add(i);
             availableTeamIds.add(i);
         }
+        this.teamSizeLimit = maxTeamSize;
+    }
+
+    public void adjustLimit(int maxPlayers, int maxTeamSize) {
+        if (locked) {
+            return;
+        }
+
+        if (maxPlayers == this.maxPlayersLimit && maxTeamSize == this.teamSizeLimit) {
+            return;
+        }
+        if (maxPlayers < this.maxPlayersLimit || maxTeamSize < this.teamSizeLimit) { // 简单起见，不检查清理的必要性
+            clear(maxPlayers, maxTeamSize);
+            return;
+        }
+        extendLimit(maxPlayers, maxTeamSize);
     }
 
     /**
@@ -147,9 +159,11 @@ public class TeamData extends AbstractGameManagerData {
         }
 
         if (!availablePlayerIds.remove(playerId)) {
+            BattleRoyale.LOGGER.warn("Can't add GamePlayer {} to team {} as playerId {} not available", gamePlayer.getPlayerName(), gameTeam.getGameTeamId(), playerId);
             return false;
         }
         if (gameTeam.getTeamMemberCount() >= teamSizeLimit) {
+            BattleRoyale.LOGGER.debug("Can't add GamePlayer {} to team {} as team size {} >= teamSizeLimit {}", gamePlayer.getPlayerName(), gameTeam.getGameTeamId(), gameTeam.getTeamMemberCount(), teamSizeLimit);
             return false;
         }
         gamePlayer.setTeam(gameTeam);

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
@@ -389,6 +389,7 @@ public class TeamManager extends AbstractGameManager {
                 GameManager.get().notifyTeamChange(targetTeam.getGameTeamId()); // 玩家加入队伍，通知更新队伍HUD
                 return;
             }
+            BattleRoyale.LOGGER.debug("Failed to add player {} to team {}", player.getName().getString(), targetTeamId);
             ChatUtils.sendTranslatableMessageToPlayer(player, Component.translatable("battleroyale.message.failed_to_join_team", targetTeam.getGameTeamId()).withStyle(ChatFormatting.RED));
         } else { // 改为发送邀请
             RequestPlayer(player, (ServerPlayer) serverLevel.getPlayerByUUID(targetTeam.getLeaderUUID()));
@@ -843,6 +844,7 @@ public class TeamManager extends AbstractGameManager {
         }
         GameTeam newTeam = new GameTeam(teamId, teamConfig.getTeamColor(teamId));
         if (!teamData.addGameTeam(newTeam)) {
+            BattleRoyale.LOGGER.debug("Failed to create new team {} and let {} join", teamId, player.getName().getString());
             ChatUtils.sendTranslatableMessageToPlayer(player, Component.translatable("battleroyale.message.failed_to_join_team", teamId).withStyle(ChatFormatting.RED));
             return false;
         }
@@ -954,12 +956,7 @@ public class TeamManager extends AbstractGameManager {
      * 尝试清除队伍信息，如果新的玩家数量限制缩小则清除，扩大限制则扩大可用id池
      */
     private void clearOrUpdateTeamIfLimitChanged() {
-        if (this.teamConfig.playerLimit < teamData.getMaxPlayersLimit() || this.teamConfig.teamSize < teamData.getTeamSizeLimit()) { // 玩家人数上限缩小/队伍规模缩小 -> 清空所有队伍
-            BattleRoyale.LOGGER.info("TeamManager: playerLimit or teamSize reduced and require clear team info");
-            this.clear(); // 重新读取配置时的clear
-        } else if (this.teamConfig.playerLimit > teamData.getMaxPlayersLimit() || this.teamConfig.teamSize > teamData.getTeamSizeLimit()) { // 玩家人数上限增多 -> 提示扩容
-            teamData.extendLimit(this.teamConfig.playerLimit, this.teamConfig.teamSize);
-        }
+        this.teamData.adjustLimit(this.teamConfig.playerLimit, this.teamConfig.teamSize);
     }
 
     /**

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
@@ -109,6 +109,12 @@ public class TeamManager extends AbstractGameManager {
                 onlinePlayers = onlinePlayers.subList(0, this.teamConfig.playerLimit);
             }
             for (ServerPlayer player : onlinePlayers) {
+                GamePlayer gamePlayer = getGamePlayerByUUID(player.getUUID());
+                if (gamePlayer != null) { // 如果keepTeamAfterGame为false，这里应该不通过
+                    // 到这里要么GamePlayer没清理掉，要么就是已经有队伍，那就保留
+                    BattleRoyale.LOGGER.debug("ServerPlayer {} is already a GamePlayer (singleId:{}, teamId:{}), skipped forceJoinTeam", player.getName().getString(), gamePlayer.getGameSingleId(), gamePlayer.getGameTeamId());
+                    continue;
+                }
                 forceJoinTeam(player); // 初始化时先强制分配，后续调整玩家自行处理
             }
         }

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
@@ -112,6 +112,7 @@ public class TeamManager extends AbstractGameManager {
                 GamePlayer gamePlayer = getGamePlayerByUUID(player.getUUID());
                 if (gamePlayer != null) { // 如果keepTeamAfterGame为false，这里应该不通过
                     // 到这里要么GamePlayer没清理掉，要么就是已经有队伍，那就保留
+                    gamePlayer.reset();
                     BattleRoyale.LOGGER.debug("ServerPlayer {} is already a GamePlayer (singleId:{}, teamId:{}), skipped forceJoinTeam", player.getName().getString(), gamePlayer.getGameSingleId(), gamePlayer.getGameTeamId());
                     continue;
                 }

--- a/src/main/java/xiao/battleroyale/config/AbstractConfigManager.java
+++ b/src/main/java/xiao/battleroyale/config/AbstractConfigManager.java
@@ -28,7 +28,7 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
     public static String MOD_CONFIG_PATH = "config/battleroyale";
 
     protected final int DEFAULT_CONFIG_FOLDER = 0;
-    protected final Map<Integer, FolderConfigData<T>> allFolderConfigData = new HashMap<>();
+    protected final Map<Integer, FolderConfigData<T>> allFolderConfigData = new HashMap<>(); // folderId -> 文件夹下配置
 
     /**
      * 获取特定子文件夹的数据
@@ -41,7 +41,7 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
         if (allFolderConfigData.containsKey(folderId)) {
             return allFolderConfigData.get(folderId);
         } else { // 默认不会触发，触发了也别崩溃
-            BattleRoyale.LOGGER.error("Unexpected ConfigManager folderId {}, default config dir: {}", folderId, getConfigDirPath());
+            BattleRoyale.LOGGER.error("Unexpected ConfigManager folderId {}, default config dir: {}, default folderId: {}", folderId, getConfigDirPath(), DEFAULT_CONFIG_FOLDER);
             return allFolderConfigData.get(DEFAULT_CONFIG_FOLDER);
         }
     }
@@ -56,7 +56,7 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
     protected static class FolderConfigData<T extends IConfigSingleEntry> {
         public int DEFAULT_CONFIG_ID = 0;
         public final Map<String, ClassUtils.ArrayMap<Integer, T>> fileConfigsByFileName; // fileName -> .json
-        public ClassUtils.ArrayMap<Integer, T> currentConfigs; // 当前json文件数据
+        public ClassUtils.ArrayMap<Integer, T> currentConfigs; // 当前json文件数据，id -> 单个配置
         public final ConfigFileName configFileName = new ConfigFileName();
 
         public FolderConfigData() {
@@ -92,22 +92,24 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
         }
         return externalView;
     }
+
     // 获取指定文件夹下当前选中的json文件数据
     protected Map<Integer, T> getConfigs() { return getConfigs(DEFAULT_CONFIG_FOLDER); }
     protected Map<Integer, T> getConfigs(int folderId) { return getConfigFolderData(folderId).currentConfigs.asMap(); }
     protected List<T> getConfigsList() { return getConfigsList(DEFAULT_CONFIG_FOLDER); }
     protected List<T> getConfigsList(int folderId) { return getConfigFolderData(folderId).currentConfigs.asList(); }
+
     // 获取指定文件夹下当前选中的json文件名
     protected ConfigFileName getConfigFileName() { return getConfigFileName(DEFAULT_CONFIG_FOLDER); }
     protected ConfigFileName getConfigFileName(int folderId) { return getConfigFolderData(folderId).configFileName; }
 
     protected Comparator<T> getConfigIdComparator() {
-        return getConfigIdComparator(getDefaultConfigId());
+        return getConfigIdComparator(DEFAULT_CONFIG_FOLDER);
     }
     protected abstract Comparator<T> getConfigIdComparator(int folderId);
 
     protected void clear() {
-        this.clear(getDefaultConfigId());
+        this.clear(DEFAULT_CONFIG_FOLDER);
     }
     protected void clear(int folderId) {
         getConfigFolderData(folderId).fileConfigsByFileName.clear();
@@ -201,37 +203,37 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
      * IConfigManager
      */
     @Override public @Nullable T getConfigEntry(int id) {
-        return getConfigEntry(id, getDefaultConfigId());
+        return getConfigEntry(id, DEFAULT_CONFIG_FOLDER);
     }
     @Override public @Nullable T getConfigEntry(int id, int folderId) {
         return getConfigFolderData(folderId).currentConfigs.mapGet(id);
     }
     @Override public @Nullable  List<T> getConfigEntryList() {
-        return getConfigEntryList(getDefaultConfigId());
+        return getConfigEntryList(DEFAULT_CONFIG_FOLDER);
     }
     @Override public @Nullable List<T> getConfigEntryList(int folderId) {
         return getConfigFolderData(folderId).currentConfigs.asList();
     }
     @Override public String getConfigEntryFileName() {
-        return getConfigEntryFileName(getDefaultConfigId());
+        return getConfigEntryFileName(DEFAULT_CONFIG_FOLDER);
     }
     @Override public String getConfigEntryFileName(int folderId) {
         return getConfigFileName(folderId).string;
     }
     @Override public String getFolderType() {
-        return getFolderType(getDefaultConfigId());
+        return getFolderType(DEFAULT_CONFIG_FOLDER);
     }
     /**
      * IConfigLoadable
      */
     @Override public Set<String> getAvailableConfigFileNames() {
-        return getAvailableConfigFileNames(getDefaultConfigId());
+        return getAvailableConfigFileNames(DEFAULT_CONFIG_FOLDER);
     }
     @Override public Set<String> getAvailableConfigFileNames(int folderId) {
         return getConfigFolderData(folderId).fileConfigsByFileName.keySet();
     }
     @Override public boolean reloadConfigs() {
-        return reloadConfigs(getDefaultConfigId());
+        return reloadConfigs(DEFAULT_CONFIG_FOLDER);
     }
     @Override public boolean reloadConfigs(int folderId) { // 读取子文件夹下所有文件数据
         String fileNameString = getConfigFileName(folderId).string; // 在清除前获取当前使用的配置文件名称
@@ -260,7 +262,6 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
             fileNameString = getConfigFolderData(folderId).fileConfigsByFileName.keySet().iterator().next();
         }
 
-        boolean defaultSelected = false;
         // 遍历每个配置文件
         for (Map.Entry<String, ClassUtils.ArrayMap<Integer, T>> entry : getConfigFolderData(folderId).fileConfigsByFileName.entrySet()) {
             // 遍历文件内每个配置
@@ -272,28 +273,27 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
                 if (switchConfigFile(fileNameString, folderId)) { // 先切换到配置再应用默认
                     configEntry.applyDefault();
                     BattleRoyale.LOGGER.info("Applied default config, fileName:{}, configId:{}, type:{}", fileNameString, configEntry.getConfigId(), configEntry.getType());
-                    defaultSelected = true;
-                    break;
+                    return true;
                 } else {
                     BattleRoyale.LOGGER.error("Unexpected config file switch, fileNameString:{}, configEntryId:{}, type:{}", fileNameString, configEntry.getConfigId(), configEntry.getType());
                 }
             }
-            if (defaultSelected) break;
         }
+        BattleRoyale.LOGGER.info("No default {} applied", getFolderType(folderId));
         return switchConfigFile(fileNameString, folderId);
     }
     @Override public @Nullable T parseConfigEntry(JsonObject jsonObject, Path filePath) {
-        return parseConfigEntry(jsonObject, filePath, getDefaultConfigId());
+        return parseConfigEntry(jsonObject, filePath, DEFAULT_CONFIG_FOLDER);
     }
     @Override public boolean hasConfigLoaded() {
-        return hasConfigLoaded(getDefaultConfigId());
+        return hasConfigLoaded(DEFAULT_CONFIG_FOLDER);
     }
     @Override public boolean hasConfigLoaded(int folderId) { // 仅判断是否已经读取到数据，不代表已经选中
         Map<String, ClassUtils.ArrayMap<Integer, T>> fileConfigs = getConfigFolderData(folderId).fileConfigsByFileName;
         return !fileConfigs.isEmpty() && fileConfigs.values().stream().anyMatch(arrayMap -> !arrayMap.isEmpty());
     }
     @Override public void initializeDefaultConfigsIfEmpty() {
-        initializeDefaultConfigsIfEmpty(getDefaultConfigId());
+        initializeDefaultConfigsIfEmpty(DEFAULT_CONFIG_FOLDER);
     }
     @Override public void initializeDefaultConfigsIfEmpty(int folderId) {
         if (hasConfigLoaded(folderId)) { // 防御一下
@@ -303,16 +303,16 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
         BattleRoyale.LOGGER.info("Generated default configs in {}", getConfigDirPath(folderId));
     }
     @Override  public String getConfigPath() {
-        return getConfigPath(getDefaultConfigId());
+        return getConfigPath(DEFAULT_CONFIG_FOLDER);
     }
     @Override public String getConfigPath(int folderId) {
         return MOD_CONFIG_PATH;
     }
     @Override public String getConfigSubPath() {
-        return getConfigSubPath(getDefaultConfigId());
+        return getConfigSubPath(DEFAULT_CONFIG_FOLDER);
     }
     @Override public Path getConfigDirPath() {
-        return getConfigDirPath(getDefaultConfigId());
+        return getConfigDirPath(DEFAULT_CONFIG_FOLDER);
     }
     @Override public Path getConfigDirPath(int folderId) {
         return Paths.get(getConfigPath(folderId)).resolve(getConfigSubPath(folderId));
@@ -323,10 +323,10 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
      */
     @Override
     public boolean switchConfigFile() {
-        return switchConfigFile(getDefaultConfigId());
+        return switchConfigFile(DEFAULT_CONFIG_FOLDER);
     }
     @Override
-    public boolean switchConfigFile(int folderId) {
+    public boolean switchConfigFile(int folderId) { // 切换下一个配置
         List<String> fileNames = new ArrayList<>(getConfigFolderData(folderId).fileConfigsByFileName.keySet());
         if (fileNames.isEmpty()) {
             return false;
@@ -340,10 +340,10 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
     }
     @Override
     public boolean switchConfigFile(String fileName) {
-        return switchConfigFile(fileName, getDefaultConfigId());
+        return switchConfigFile(fileName, DEFAULT_CONFIG_FOLDER);
     }
     @Override
-    public boolean switchConfigFile(@NotNull String fileName, int folderId) {
+    public boolean switchConfigFile(@NotNull String fileName, int folderId) { // 指定文件名切换配置
         ClassUtils.ArrayMap<Integer, T> selectedFileConfigs = getConfigFolderData(folderId).fileConfigsByFileName.get(fileName);
 
         if (selectedFileConfigs != null) {
@@ -361,7 +361,7 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
      * IConfigDefaultable
      */
     @Override public void generateDefaultConfigs() {
-        generateDefaultConfigs(getDefaultConfigId());
+        generateDefaultConfigs(DEFAULT_CONFIG_FOLDER);
     }
     @Override public int getDefaultConfigId() {
         return getDefaultConfigId(DEFAULT_CONFIG_FOLDER);
@@ -370,13 +370,13 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
         return getConfigFolderData(folderId).DEFAULT_CONFIG_ID;
     }
     @Override public void setDefaultConfigId(int id) {
-        setDefaultConfigId(id, getDefaultConfigId());
+        setDefaultConfigId(id, DEFAULT_CONFIG_FOLDER);
     }
     @Override public void setDefaultConfigId(int id, int folderId) {
         getConfigFolderData(folderId).DEFAULT_CONFIG_ID = id;
     }
     @Override public @Nullable T getDefaultConfig() {
-        return getDefaultConfig(getDefaultConfigId());
+        return getDefaultConfig(DEFAULT_CONFIG_FOLDER);
     }
     @Override public @Nullable T getDefaultConfig(int folderId) {
         return getConfigEntry(getDefaultConfigId(folderId));

--- a/src/main/java/xiao/battleroyale/config/client/render/defaultconfigs/DefaultRender.java
+++ b/src/main/java/xiao/battleroyale/config/client/render/defaultconfigs/DefaultRender.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import xiao.battleroyale.config.client.ClientConfigManager;
 import xiao.battleroyale.config.client.render.RenderConfigManager.RenderConfig;
 import xiao.battleroyale.config.client.render.type.BlockEntry;
+import xiao.battleroyale.config.client.render.type.TeamEntry;
 import xiao.battleroyale.config.client.render.type.ZoneEntry;
 
 import java.nio.file.Paths;
@@ -27,8 +28,9 @@ public class DefaultRender {
     private static JsonObject generateDefaultRenderConfig0() {
         BlockEntry blockEntry = new BlockEntry(16);
         ZoneEntry zoneEntry = new ZoneEntry(false);
+        TeamEntry teamEntry = new TeamEntry(true, false);
 
-        RenderConfig renderConfig = new RenderConfig(0, "No limit", "#FFFFFFAA", blockEntry, zoneEntry);
+        RenderConfig renderConfig = new RenderConfig(0, "No limit", "#FFFFFFAA", true, blockEntry, zoneEntry, teamEntry);
 
         return renderConfig.toJson();
     }
@@ -36,8 +38,9 @@ public class DefaultRender {
     private static JsonObject generateDefaultRenderConfig1() {
         BlockEntry blockEntry = new BlockEntry(0);
         ZoneEntry zoneEntry = new ZoneEntry(true, "#0000FF", 64, 64, 64, 64);
+        TeamEntry teamEntry = new TeamEntry(true, true);
 
-        RenderConfig renderConfig = new RenderConfig(1, "Client single color", "#FFFFFFAA", blockEntry, zoneEntry);
+        RenderConfig renderConfig = new RenderConfig(1, "Client single color", "#FFFFFFAA", blockEntry, zoneEntry, teamEntry);
 
         return renderConfig.toJson();
     }
@@ -45,8 +48,9 @@ public class DefaultRender {
     private static JsonObject generateDefaultRenderConfig2() {
         BlockEntry blockEntry = new BlockEntry(8000);
         ZoneEntry zoneEntry = new ZoneEntry(false, "", 1024, 1024, 1024, 1024);
+        TeamEntry teamEntry = new TeamEntry(true, false);
 
-        RenderConfig renderConfig = new RenderConfig(2, "Max render", "#FFFFFFAA", blockEntry, zoneEntry);
+        RenderConfig renderConfig = new RenderConfig(2, "Max render", "#FFFFFFAA", blockEntry, zoneEntry, teamEntry);
 
         return renderConfig.toJson();
     }
@@ -54,8 +58,10 @@ public class DefaultRender {
     private static JsonObject generateDefaultRenderConfig3() {
         BlockEntry blockEntry = new BlockEntry(4);
         ZoneEntry zoneEntry = new ZoneEntry(false, "", 32, 32, 32, 32);
+        TeamEntry teamEntry = new TeamEntry(true, false, "",
+                false, true, 0.5F);
 
-        RenderConfig renderConfig = new RenderConfig(3, "Better Performance", "#FFFFFFAA", blockEntry, zoneEntry);
+        RenderConfig renderConfig = new RenderConfig(3, "Better Performance", "#FFFFFFAA", blockEntry, zoneEntry, teamEntry);
 
         return renderConfig.toJson();
     }

--- a/src/main/java/xiao/battleroyale/config/client/render/type/TeamEntry.java
+++ b/src/main/java/xiao/battleroyale/config/client/render/type/TeamEntry.java
@@ -1,0 +1,82 @@
+package xiao.battleroyale.config.client.render.type;
+
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
+import xiao.battleroyale.api.client.render.IRenderEntry;
+import xiao.battleroyale.api.client.render.RenderConfigTag;
+import xiao.battleroyale.client.renderer.game.TeamMemberRenderer;
+import xiao.battleroyale.util.JsonUtils;
+
+public class TeamEntry implements IRenderEntry {
+
+    public final boolean enableTeamZone;
+    public final boolean useClientColor;
+    public final String fixedColor;
+    public final boolean renderBeacon;
+    public final boolean renderBoundingBox;
+    public final float transparency;
+
+    public TeamEntry(boolean enableTeamZone, boolean useClientColor) {
+        this(enableTeamZone, useClientColor, "#00FFFF",
+                true, true, 0.5F);
+    }
+
+    public TeamEntry(boolean enableTeamZone, boolean useClientColor, String fixedColor,
+                     boolean renderBeacon, boolean renderBoundingBox, float transparency) {
+        this.enableTeamZone = enableTeamZone;
+        this.useClientColor = useClientColor;
+        this.fixedColor = fixedColor;
+        this.renderBeacon = renderBeacon;
+        this.renderBoundingBox = renderBoundingBox;
+        this.transparency = transparency;
+    }
+
+    @Override
+    public String getType() {
+        return "TeamEntry";
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty(RenderConfigTag.ENABLE_TEAM_ZONE, enableTeamZone);
+        if (!enableTeamZone) {
+            return jsonObject;
+        }
+        jsonObject.addProperty(RenderConfigTag.USE_CLIENT_COLOR, useClientColor);
+        if (useClientColor) {
+            jsonObject.addProperty(RenderConfigTag.FIXED_COLOR, fixedColor);
+        }
+        jsonObject.addProperty(RenderConfigTag.RENDER_BEACON, renderBeacon);
+        jsonObject.addProperty(RenderConfigTag.RENDER_BOUNDING_BOX, renderBoundingBox);
+        jsonObject.addProperty(RenderConfigTag.TRANSPARENCY, transparency);
+
+        return jsonObject;
+    }
+
+    @NotNull
+    public static TeamEntry fromJson(JsonObject jsonObject) {
+        boolean enableTeamZone = JsonUtils.getJsonBool(jsonObject, RenderConfigTag.ENABLE_TEAM_ZONE, true);
+        boolean useClientColor = JsonUtils.getJsonBool(jsonObject, RenderConfigTag.USE_CLIENT_COLOR, false);
+        String fixedColor = JsonUtils.getJsonString(jsonObject, RenderConfigTag.FIXED_COLOR, "");
+        boolean headBeacon = JsonUtils.getJsonBool(jsonObject, RenderConfigTag.RENDER_BEACON, true);
+        boolean boundingBox = JsonUtils.getJsonBool(jsonObject, RenderConfigTag.RENDER_BOUNDING_BOX, true);
+        float transparency = (float) JsonUtils.getJsonDouble(jsonObject, RenderConfigTag.TRANSPARENCY, 0.5);
+
+        return new TeamEntry(enableTeamZone, useClientColor, fixedColor, headBeacon, boundingBox, transparency);
+    }
+
+    @Override
+    public void applyDefault() {
+        TeamMemberRenderer.setEnableTeamZone(enableTeamZone);
+        if (enableTeamZone) {
+            TeamMemberRenderer.setUseClientColor(useClientColor);
+            if (useClientColor) {
+                TeamMemberRenderer.setClientColorString(fixedColor);
+            }
+            TeamMemberRenderer.setRenderBeacon(renderBeacon);
+            TeamMemberRenderer.setRenderBoundingBox(renderBoundingBox);
+            TeamMemberRenderer.setTransparency(transparency);
+        }
+    }
+}

--- a/src/main/java/xiao/battleroyale/config/common/loot/defaultconfigs/DefaultLootConfigGenerator.java
+++ b/src/main/java/xiao/battleroyale/config/common/loot/defaultconfigs/DefaultLootConfigGenerator.java
@@ -13,6 +13,7 @@ public class DefaultLootConfigGenerator {
     public static void generateDefaultLootSpawnerConfig() {
         DefaultLootSpawner.generateDefaultConfigs();
         TaczLootSpawner.generateDefaultConfigs();
+        TaczLootSpawner.generateExtraConfigs();
     }
 
     public static void generateDefaultAirdropConfig() {

--- a/src/main/java/xiao/battleroyale/config/common/loot/defaultconfigs/TaczLootSpawner.java
+++ b/src/main/java/xiao/battleroyale/config/common/loot/defaultconfigs/TaczLootSpawner.java
@@ -19,12 +19,20 @@ import static xiao.battleroyale.api.minecraft.EquipmentLevel.*;
 public class TaczLootSpawner {
 
     private static final String DEFAULT_FILE_NAME = "example_tacz_1.1.6.json";
+    private static final String EXTRA_FILE_NAME = "example_tacz_1.1.6_extra.json";
 
     public static void generateDefaultConfigs() {
         JsonArray lootSpawnerConfigsJson = new JsonArray();
         lootSpawnerConfigsJson.add(generateTaczCommonLoot());
         lootSpawnerConfigsJson.add(generateTaczRareLoot());
         writeJsonToFile(Paths.get(LootConfigManager.get().getConfigPath(LOOT_SPAWNER), LootConfigManager.LOOT_SPAWNER_CONFIG_SUB_PATH, DEFAULT_FILE_NAME).toString(), lootSpawnerConfigsJson);
+    }
+
+    public static void generateExtraConfigs() {
+        JsonArray lootSpawnerConfigsJson = new JsonArray();
+        lootSpawnerConfigsJson.add(generateTaczExtraLoot());
+        lootSpawnerConfigsJson.add(generateTaczRareLoot());
+        writeJsonToFile(Paths.get(LootConfigManager.get().getConfigPath(LOOT_SPAWNER), LootConfigManager.LOOT_SPAWNER_CONFIG_SUB_PATH, EXTRA_FILE_NAME).toString(), lootSpawnerConfigsJson);
     }
 
     /**
@@ -36,12 +44,12 @@ public class TaczLootSpawner {
      */
     private static JsonObject generateTaczCommonLoot() {
         WeightEntry itemTypeWeight = new WeightEntry(Arrays.asList(
-                new WeightedEntry(32, commonWeaponEntry()),
+                new WeightedEntry(30, commonWeaponEntry()),
                 new WeightedEntry(22, commonAttachmentEntry()),
                 new WeightedEntry(8, commonAmmoEntry()),
                 new WeightedEntry(22, commomEquipmentEntry()),
                 new WeightedEntry(8, commonHealEntry()),
-                new WeightedEntry(8, commonToolEntry())
+                new WeightedEntry(10, commonToolEntry())
         ));
         RepeatEntry repeatEntry = new RepeatEntry(1, 3, itemTypeWeight);
 
@@ -57,18 +65,46 @@ public class TaczLootSpawner {
         return lootConfig.toJson();
     }
 
-    private static JsonObject generateTaczRareLoot() {
-        MultiEntry itemList = new MultiEntry(Arrays.asList(
+    private static JsonObject generateTaczExtraLoot() {
+        WeightEntry itemTypeWeight = new WeightEntry(Arrays.asList(
+                new WeightedEntry(30, commonWeaponEntry()),
+                new WeightedEntry(22, commonAttachmentEntry()),
+                new WeightedEntry(8, commonAmmoEntry()),
+                new WeightedEntry(22, commomEquipmentEntry()),
+                new WeightedEntry(8, commonHealEntry()),
+                new WeightedEntry(10, commonToolEntry())
+        ));
+        RepeatEntry repeatEntry = new RepeatEntry(3, 6, itemTypeWeight);
+
+        MultiEntry multiEntry = new MultiEntry(Arrays.asList(
+                repeatEntry,
+                minecraftItemEntry(),
+                specialItemEntry(),
+                generateExtraRareLootEntry()
+        ));
+
+        LootConfig lootConfig = new LootConfig(0, "Widespread common loot (extra rare)", "#FFFFFFAA",
+                multiEntry);
+
+        return lootConfig.toJson();
+    }
+    private static ILootEntry generateExtraRareLootEntry() {
+        return new ExtraEntry(false, true,
+                new RandomEntry(0.01, generateTaczRareLootEntry()),
+                new MessageEntry(false, true, "Rare loot generated！", "#FF0000"));
+    }
+
+    private static ILootEntry generateTaczRareLootEntry() {
+        return new MultiEntry(Arrays.asList(
                 rareWeaponEntry(),
                 rareAttachmentEntry(),
                 rareAmmoEntry(),
                 rareEquipmentEntry()
         ));
-
-        RepeatEntry repeatEntry = new RepeatEntry(2, 2, itemList);
-
+    }
+    private static JsonObject generateTaczRareLoot() {
         LootConfig lootConfig = new LootConfig(1, "Rare high-tier loots", "#FFFFFFAA",
-                repeatEntry);
+                new RepeatEntry(2, 2, generateTaczRareLootEntry()));
 
         return lootConfig.toJson();
     }
@@ -121,13 +157,13 @@ public class TaczLootSpawner {
 
     private static ILootEntry commonWeaponEntry() {
         WeightEntry weaponTypeWeight = new WeightEntry(Arrays.asList(
-                new WeightedEntry(25, commonAREntry()),
+                new WeightedEntry(23, commonAREntry()),
                 new WeightedEntry(11, commonSREntry()),
                 new WeightedEntry(12, commonDMREntry()),
                 new WeightedEntry(13, commonShotgunEntry()),
-                new WeightedEntry(25, commonSMGEntry()),
+                new WeightedEntry(22, commonSMGEntry()),
                 new WeightedEntry(8, commonPistolEntry()),
-                new WeightedEntry(6, commonMeleeEntry())
+                new WeightedEntry(11, commonMeleeEntry())
         ));
 
         return weaponTypeWeight;
@@ -685,9 +721,9 @@ public class TaczLootSpawner {
      */
     private static ILootEntry commomEquipmentEntry() {
         return new WeightEntry(Arrays.asList(
-                new WeightedEntry(50, commonVestEntry()),
+                new WeightedEntry(45, commonVestEntry()),
                 new WeightedEntry(30, commonLeggingsEntry()),
-                new WeightedEntry(20, commonHelmetEntry())
+                new WeightedEntry(25, commonHelmetEntry())
         ));
     }
 
@@ -701,44 +737,44 @@ public class TaczLootSpawner {
 
     private static ILootEntry commonHelmetEntry() {
         return new WeightEntry(Arrays.asList(
-                new WeightedEntry(65, EquipmentLevel.equipment(LEATHER, HELMET, 3)),
-                new WeightedEntry(35, EquipmentLevel.equipment(CHAINMAIL, HELMET, 4))
+                new WeightedEntry(55, EquipmentLevel.equipment(CHAINMAIL, HELMET, 10, 3)),
+                new WeightedEntry(45, EquipmentLevel.equipment(IRON, HELMET, 15, 5))
         ));
     }
 
     private static ILootEntry rareHelmetEntry() {
         return new WeightEntry(Arrays.asList(
-                new WeightedEntry(80, EquipmentLevel.equipment(CHAINMAIL, HELMET, 4)),
-                new WeightedEntry(20, EquipmentLevel.equipment(DIAMOND, HELMET, 4))
+                new WeightedEntry(70, EquipmentLevel.equipment(IRON, HELMET, 15, 5)),
+                new WeightedEntry(30, EquipmentLevel.equipment(NETHERITE, HELMET, 20, 8))
         ));
     }
 
     private static ILootEntry commonVestEntry() {
         return new WeightEntry(Arrays.asList(
-                new WeightedEntry(65, EquipmentLevel.equipment(LEATHER, CHESTPLATE, 14)),
-                new WeightedEntry(30, EquipmentLevel.equipment(CHAINMAIL, CHESTPLATE, 12)),
-                new WeightedEntry(5, EquipmentLevel.equipment(DIAMOND, CHESTPLATE, 10))
+                new WeightedEntry(55, EquipmentLevel.equipment(CHAINMAIL, CHESTPLATE, 15, 1)),
+                new WeightedEntry(40, EquipmentLevel.equipment(IRON, CHESTPLATE, 20, 3)),
+                new WeightedEntry(5, EquipmentLevel.equipment(DIAMOND, CHESTPLATE, 25, 5))
         ));
     }
 
     private static ILootEntry rareVestEntry() {
         return new WeightEntry(Arrays.asList(
-                new WeightedEntry(70, EquipmentLevel.equipment(CHAINMAIL, CHESTPLATE, 12)),
-                new WeightedEntry(30, EquipmentLevel.equipment(DIAMOND, CHESTPLATE, 10))
+                new WeightedEntry(60, EquipmentLevel.equipment(IRON, CHESTPLATE, 20, 3)),
+                new WeightedEntry(40, EquipmentLevel.equipment(DIAMOND, CHESTPLATE, 25, 5))
         ));
     }
 
     private static ILootEntry commonLeggingsEntry() {
         return new WeightEntry(Arrays.asList(
-                new WeightedEntry(65, EquipmentLevel.equipment(LEATHER, LEGGINGS, 5)),
-                new WeightedEntry(35, EquipmentLevel.equipment(CHAINMAIL, LEGGINGS, 7))
+                new WeightedEntry(65, EquipmentLevel.equipment(CHAINMAIL, LEGGINGS, 13, 1)),
+                new WeightedEntry(35, EquipmentLevel.equipment(IRON, LEGGINGS, 18, 3))
         ));
     }
 
     private static ILootEntry rareLeggingsEntry() {
         return new WeightEntry(Arrays.asList(
-                new WeightedEntry(75, EquipmentLevel.equipment(CHAINMAIL, LEGGINGS, 7)),
-                new WeightedEntry(25, EquipmentLevel.equipment(DIAMOND, LEGGINGS, 9))
+                new WeightedEntry(55, EquipmentLevel.equipment(IRON, LEGGINGS, 18, 3)),
+                new WeightedEntry(45, EquipmentLevel.equipment(DIAMOND, LEGGINGS, 23, 5))
         ));
     }
 
@@ -746,10 +782,10 @@ public class TaczLootSpawner {
         return new WeightEntry(Arrays.asList(
                 new WeightedEntry(28, new ItemEntry("minecraft:potion", "{Potion:\"minecraft:empty\",display:{Name:'{\"text\":\"Bandage\",\"color\":\"white\",\"italic\":false}'},CustomPotionEffects:[{Id:10,Amplifier:0,Duration:100,ShowParticles:0b,Ambient:0b}]}", 1)),
                 new WeightedEntry(16, new ItemEntry("minecraft:potion", "{Potion:\"minecraft:empty\",display:{Name:'{\"text\":\"First Aid Kit\",\"color\":\"red\",\"italic\":false}'},CustomPotionEffects:[{Id:10,Amplifier:3,Duration:90,ShowParticles:0b,Ambient:0b}]}", 1)),
-                new WeightedEntry(2, new ItemEntry("minecraft:potion", "{Potion:\"minecraft:empty\",display:{Name:'{\"text\":\"Med Kit\",\"color\":\"blue\",\"italic\":false}'},CustomPotionEffects:[{Id:10,Amplifier:3,Duration:120,ShowParticles:0b,Ambient:0b}]}", 1)),
-                new WeightedEntry(27, new EmptyEntry("item")),
-                new WeightedEntry(24, new EmptyEntry("item")),
-                new WeightedEntry(3, new EmptyEntry("item"))
+                new WeightedEntry(2, new ItemEntry("minecraft:potion", "{Potion:\"minecraft:empty\",display:{Name:'{\"text\":\"Med Kit\",\"color\":\"blue\",\"italic\":false}'},CustomPotionEffects:[{Id:10,Amplifier:3,Duration:120,ShowParticles:0b,Ambient:0b}]}", 1))
+                // new WeightedEntry(27, new EmptyEntry("item")),
+                // new WeightedEntry(24, new EmptyEntry("item")),
+                // new WeightedEntry(3, new EmptyEntry("item"))
         ));
     }
 
@@ -759,9 +795,9 @@ public class TaczLootSpawner {
                 new WeightedEntry(26, new ItemEntry("lrtactical:throwable", "{ThrowableId:\"lrtactical:smoke_grenade\"}", 1)),
                 new WeightedEntry(18, new ItemEntry("lrtactical:throwable", "{ThrowableId:\"lrtactical:molotov\"}", 1)),
                 new WeightedEntry(22, new ItemEntry("lrtactical:throwable", "{ThrowableId:\"lrtactical:flash_grenade\"}", 1)),
-                new WeightedEntry(3, new EmptyEntry("item")),
-                new WeightedEntry(5, new ItemEntry("vc_gliders:paraglider_wood", "{Damage:25}", 1)),
-                new WeightedEntry(10, new EmptyEntry("item"))
+                // new WeightedEntry(3, new EmptyEntry("item")),
+                new WeightedEntry(5, new ItemEntry("vc_gliders:paraglider_wood", "{Damage:25}", 1))
+                // new WeightedEntry(10, new EmptyEntry("item"))
         ));
     }
 }

--- a/src/main/java/xiao/battleroyale/config/common/loot/defaultconfigs/TaczLootSpawner.java
+++ b/src/main/java/xiao/battleroyale/config/common/loot/defaultconfigs/TaczLootSpawner.java
@@ -181,21 +181,44 @@ public class TaczLootSpawner {
 
     // 全自动
     private static MultiEntry gunAmmoBuilder(String gunName, String ammoName, int ammoCount) {
-        return gunAmmoBuilder(gunName, ammoName, ammoCount, "AUTO");
+        return gunAmmoBuilderEmpty(gunName, ammoName, ammoCount, "AUTO");
     }
 
     private static MultiEntry gunBurstAmmoBuilder(String gunName, String ammoName, int ammoCount) {
-        return gunAmmoBuilder(gunName, ammoName, ammoCount, "BURST");
+        return gunAmmoBuilderEmpty(gunName, ammoName, ammoCount, "BURST");
     }
 
     // 单发
     private static MultiEntry gunSemiAmmoBuilder(String gunName, String ammoName, int ammoCount) {
-        return gunAmmoBuilder(gunName, ammoName, ammoCount, "SEMI");
+        return gunAmmoBuilderEmpty(gunName, ammoName, ammoCount, "SEMI");
     }
 
+    /**
+     * 枪+子弹
+     */
     private static MultiEntry gunAmmoBuilder(String gunName, String ammoName, int ammoCount, String fireMode) {
         return new MultiEntry(Arrays.asList(
                 new ItemEntry("tacz:modern_kinetic_gun", "{GunId:\"tacz:" + gunName + "\",GunFireMode:\"" + fireMode + "\"}", 1),
+                ammoBuilder(ammoName, ammoCount)
+        ));
+    }
+    // 强制写入空配件的NBT标签字符串
+    private static MultiEntry gunAmmoBuilderEmpty(String gunName, String ammoName, int ammoCount, String fireMode) {
+        String emptyAttachmentsNBT = "{" +
+                "AttachmentEXTENDED_MAG: {id: \"minecraft:air\", Count:0b, tag: {struck:0b, glide:0b}}, " +
+                "HasBulletInBarrel: 0b, " +
+                "AttachmentSCOPE: {id: \"minecraft:air\", Count: 0b, tag: {struck: 0b, glide: 0b}}, " +
+                "AttachmentMUZZLE: {id: \"minecraft:air\", Count: 0b, tag: {struck: 0b, glide: 0b}}, " +
+                "AttachmentLASER: {id: \"minecraft:air\", Count: 0b, tag: {struck: 0b, glide: 0b}}, " +
+                "GunFireMode: \"" + fireMode + "\", " +
+                "GunCurrentAmmoCount: 0, " +
+                "AttachmentGRIP: {id: \"minecraft:air\", Count: 0b, tag: {struck: 0b, glide: 0b}}, " +
+                "AttachmentSTOCK: {id: \"minecraft:air\", Count: 0b, tag: {struck:0b, glide:0b}}, " +
+                "GunId: \"tacz:" + gunName + "\"" +
+                "}";
+
+        return new MultiEntry(Arrays.asList(
+                new ItemEntry("tacz:modern_kinetic_gun", emptyAttachmentsNBT, 1),
                 ammoBuilder(ammoName, ammoCount)
         ));
     }

--- a/src/main/java/xiao/battleroyale/developer/debug/DebugGame.java
+++ b/src/main/java/xiao/battleroyale/developer/debug/DebugGame.java
@@ -116,4 +116,34 @@ public class DebugGame {
     public void getGameZone(CommandSourceStack source, IGameZone gameZone) {
         DebugManager.sendDebugMessageWithGameTime(source, GET_GAME_ZONE, GameText.buildGameZoneDetail(gameZone, source.getPosition()));
     }
+
+    /**
+     * [调试]getBackupPlayermodes
+     */
+    public static final String GET_BACKUP_PLAYERMODES = "getBackupPlayermodes";
+    public void getGetBackupPlayermodes(CommandSourceStack source, int min, int max) {
+        ;
+    }
+
+    /**
+     * [调试]getBackupPlayermode
+     */
+    public static final String GET_BACKUP_PLAYERMODE = "getBackupPlayermode";
+    public void getBackupPlayermode(CommandSourceStack source, int singleId) {
+        ;
+    }
+    public void getBackupPlayermode(CommandSourceStack source, String name) {
+        ;
+    }
+    public void getBackupPlayermode(CommandSourceStack source, Entity entity) {
+        ;
+    }
+
+    /**
+     * [调试]getBackupGamerule
+     */
+    public static final String GET_BACKUP_GAMERULE = "getBackupGamerule";
+    public void getBackupGamerule(CommandSourceStack source) {
+        ;
+    }
 }

--- a/src/main/java/xiao/battleroyale/developer/debug/command/sub/get/GetGame.java
+++ b/src/main/java/xiao/battleroyale/developer/debug/command/sub/get/GetGame.java
@@ -221,11 +221,7 @@ public class GetGame {
             return 0;
         }
 
-        if (min == Integer.MIN_VALUE && max == Integer.MAX_VALUE - 1) {
-            context.getSource().sendSuccess(() -> Component.literal("Executing get backupplayermodes (all)"), false);
-        } else {
-            context.getSource().sendSuccess(() -> Component.literal("Executing get backupplayermodes with min: " + min + ", max: " + max), false);
-        }
+        DebugGame.get().getGetBackupPlayermodes(source, min, max);
         return Command.SINGLE_SUCCESS;
     }
     private static int getBackupPlayerMode(CommandContext<CommandSourceStack> context) {
@@ -235,8 +231,7 @@ public class GetGame {
             return 0;
         }
 
-        final int id = IntegerArgumentType.getInteger(context, SINGLE_ID);
-        context.getSource().sendSuccess(() -> Component.literal("Executing get backupplayermode by ID: " + id), false);
+        DebugGame.get().getBackupPlayermode(source, IntegerArgumentType.getInteger(context, SINGLE_ID));
         return Command.SINGLE_SUCCESS;
     }
     private static int getBackupPlayerModeByName(CommandContext<CommandSourceStack> context) {
@@ -246,8 +241,7 @@ public class GetGame {
             return 0;
         }
 
-        final String name = StringArgumentType.getString(context, NAME);
-        context.getSource().sendSuccess(() -> Component.literal("Executing get backupplayermode by Name: " + name), false);
+        DebugGame.get().getBackupPlayermode(source, StringArgumentType.getString(context, NAME));
         return Command.SINGLE_SUCCESS;
     }
     private static int getBackupPlayerModeByEntity(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
@@ -257,8 +251,7 @@ public class GetGame {
             return 0;
         }
 
-        Entity entity = EntityArgument.getEntity(context, ENTITY);
-        context.getSource().sendSuccess(() -> Component.literal("Executing get backupplayermode by Entity: " + entity.getName().getString() + " (UUID: " + entity.getUUID().toString() + ")"), false);
+        DebugGame.get().getBackupPlayermode(source, EntityArgument.getEntity(context, ENTITY));
         return Command.SINGLE_SUCCESS;
     }
 
@@ -272,7 +265,7 @@ public class GetGame {
             return 0;
         }
 
-        context.getSource().sendSuccess(() -> Component.literal("Executing get backupgamerule"), false);
+        DebugGame.get().getBackupGamerule(source);
         return Command.SINGLE_SUCCESS;
     }
 


### PR DESCRIPTION
- Fix zone delay stacking calculation
- Correct team size limit after switch config
- Render config add teamEntry
- Adjust default TaCZ loot config
- Cancel game players regroup at game init