### PR TITLE
0.3.6 Gamerule config update, Spectator view, default team color, config reload update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ mapping_version=1.20.1
 mod_id=battleroyale
 mod_name=Custom BattleRoyale
 mod_license=GPL-3.0 license
-mod_version=0.3.5
+mod_version=0.3.6
 mod_group_id=xiao.battleroyale
 mod_authors=XiaoColorful

--- a/src/main/java/xiao/battleroyale/api/client/render/RenderConfigTag.java
+++ b/src/main/java/xiao/battleroyale/api/client/render/RenderConfigTag.java
@@ -7,6 +7,7 @@ public class RenderConfigTag extends ConfigEntryTag {
     public static String BLOCK_ENTRY = "block";
     public static String ZONE_ENTRY = "zone";
     public static String TEAM_ENTRY = "teamEntry";
+    public static String SPECTATE_ENTRY = "spectateEntry";
 
     public static String ITEM_RENDER_DISTANCE = "itemRenderDistance";
 
@@ -18,9 +19,11 @@ public class RenderConfigTag extends ConfigEntryTag {
     public static String ELLIPSOID_SEGMENTS = "ellispoidSegments";
 
     public static String ENABLE_TEAM_ZONE = "enableTeamZone";
+    public static String ENABLE_SPECTATE_ZONE = "enableSpectateZone";
     public static String RENDER_BEACON = "renderBeacon";
     public static String RENDER_BOUNDING_BOX = "renderBoundingBox";
     public static String TRANSPARENCY = "transparency";
+    public static String SCAN_FREQUENCY = "scanFrequency";
     
     private RenderConfigTag() {}
 }

--- a/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
+++ b/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
@@ -8,6 +8,8 @@ public class GameEntryTag extends ConfigEntryTag {
     // team
     public static final String TEAM_MSG_EXPIRE_SECONDS = "teamMessageExpireSeconds";
     public static final String TEAM_COLORS = "teamColors";
+    public static final String BUILD_VANILLA_TEAM = "buildVanillaTeam";
+    public static final String HIDE_VANILLA_TEAM_NAME = "hideVanillaTeamName";
     // game
     public static final String MAX_PLAYER_INVALID_TIME = "maxPlayerInvalidTime";
     public static final String MAX_BOT_INVALID_TIME = "maxBotInvalidTime";

--- a/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
+++ b/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
@@ -19,6 +19,7 @@ public class GameEntryTag extends ConfigEntryTag {
     public static final String DOWN_DAMAGE_FREQUENCY = "downDamageFrequency";
     public static final String ONLY_GAME_PLAYER_SPECTATE = "onlyGamePlayerSpectate";
     public static final String SPECTATE_AFTER_TEAM = "spectateAfterTeamEliminated";
+    public static final String SPECTATOR_SEE_ALL_TEAMS = "spectatorSeeAllTeams";
     public static final String TELEPORT_INTERFERER_TO_LOBBY = "teleportInterfererToLobby";
     public static final String ALLOW_REMAINING_BOT = "allowRemainingBot";
     public static final String KEEP_TEAM_AFTER_GAME = "keepTeamAfterGame";

--- a/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
+++ b/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
@@ -26,6 +26,7 @@ public class GameEntryTag extends ConfigEntryTag {
     public static final String TELEPORT_WINNER_AFTER_GAME = "teleportWinnerAfterGame";
     public static final String WINNER_FIREWORK_ID = "winnerFireworkId";
     public static final String WINNER_PARTICLE_ID = "winnerParticleId";
+    public static final String INIT_GAME_AFTER_GAME = "initGameAfterGame";
     // message
     public static final String MESSAGE_CLEAN_FREQUENCY = "messageCleanFrequency";
     public static final String MESSAGE_EXPIRE_TIME = "messageExpireTime";

--- a/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
+++ b/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
@@ -13,6 +13,7 @@ public class GameEntryTag extends ConfigEntryTag {
     public static final String REMOVE_INVALID_TEAM = "removeInvalidTeam";
     public static final String HEAL_ALL_AT_START = "healAllAtStart";
     public static final String FRIENDLY_FIRE = "friendlyFire";
+    public static final String DOWN_FIRE = "downFire";
     public static final String DOWN_DAMAGE_LIST = "downDamage";
     public static final String DOWN_DAMAGE_FREQUENCY = "downDamageFrequency";
     public static final String ONLY_GAME_PLAYER_SPECTATE = "onlyGamePlayerSpectate";

--- a/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
+++ b/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
@@ -4,6 +4,7 @@ import xiao.battleroyale.api.ConfigEntryTag;
 
 public class GameEntryTag extends ConfigEntryTag {
 
+    public static final String TELEPORT_WHEN_INIT_GAME = "teleportWhenInitGame";
     // team
     public static final String TEAM_MSG_EXPIRE_SECONDS = "teamMessageExpireSeconds";
     public static final String TEAM_COLORS = "teamColors";

--- a/src/main/java/xiao/battleroyale/api/message/game/GameTag.java
+++ b/src/main/java/xiao/battleroyale/api/message/game/GameTag.java
@@ -3,6 +3,7 @@ package xiao.battleroyale.api.message.game;
 public class GameTag {
 
     public static final String ALIVE = "alive";
+    public static final String GAMEID = "gameId";
 
     private GameTag() {}
 }

--- a/src/main/java/xiao/battleroyale/client/event/ClientRenderEventHandler.java
+++ b/src/main/java/xiao/battleroyale/client/event/ClientRenderEventHandler.java
@@ -6,23 +6,22 @@ import net.minecraftforge.client.event.RenderGuiEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import xiao.battleroyale.BattleRoyale;
-import xiao.battleroyale.client.renderer.game.GameInfoRenderer;
-import xiao.battleroyale.client.renderer.game.TeamInfoRenderer;
-import xiao.battleroyale.client.renderer.game.TeamMemberRenderer;
-import xiao.battleroyale.client.renderer.game.ZoneRenderer;
+import xiao.battleroyale.client.renderer.game.*;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT, modid = BattleRoyale.MOD_ID)
 public class ClientRenderEventHandler {
 
     private static final ZoneRenderer zoneRenderer = ZoneRenderer.get();
     private static final TeamMemberRenderer teamMemberRenderer = TeamMemberRenderer.get();
-    private static final TeamInfoRenderer teamInfoRenderer = TeamInfoRenderer.get();
+    private static final SpectatePlayerRenderer SPECTATE_PLAYER_RENDERER = SpectatePlayerRenderer.get();
     private static final GameInfoRenderer gameInfoRenderer = GameInfoRenderer.get();
+    private static final TeamInfoRenderer teamInfoRenderer = TeamInfoRenderer.get();
 
     @SubscribeEvent
     public static void onRenderLevelStage(RenderLevelStageEvent event) {
         zoneRenderer.onRenderLevelStage(event);
         teamMemberRenderer.onRenderLevelStage(event); // 后绘制
+        SPECTATE_PLAYER_RENDERER.onRenderLevelStage(event);
     }
 
     @SubscribeEvent

--- a/src/main/java/xiao/battleroyale/client/game/ClientGameDataManager.java
+++ b/src/main/java/xiao/battleroyale/client/game/ClientGameDataManager.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 import xiao.battleroyale.client.game.data.ClientGameData;
 import xiao.battleroyale.client.game.data.ClientTeamData;
 import xiao.battleroyale.client.game.data.ClientSingleZoneData;
+import xiao.battleroyale.client.renderer.game.SpectatePlayerRenderer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -64,7 +65,9 @@ public class ClientGameDataManager {
             if (currentTick - gameData.getLastUpdateTick() > GAME_EXPIRE_TICK) {
                 gameData.clear();
             } else {
-                ;
+                if (currentTick % SpectatePlayerRenderer.getScanFrequency() == 0) {
+                    SpectatePlayerRenderer.get().scanSpectatePlayers();
+                }
             }
         }
         // 下一tick一开始获取bool就会重置

--- a/src/main/java/xiao/battleroyale/client/game/ClientGameDataManager.java
+++ b/src/main/java/xiao/battleroyale/client/game/ClientGameDataManager.java
@@ -112,6 +112,14 @@ public class ClientGameDataManager {
         }
     }
 
+    public void updateGameSpectateInfo(@NotNull CompoundTag syncPacketNbt) {
+        if (syncPacketNbt.isEmpty()) {
+            gameData.getSpectateData().clear();
+        } else {
+            gameData.getSpectateData().updateFromNbt(syncPacketNbt);
+        }
+    }
+
     public void clear() {
         activeZones.clear();
         teamData.clear();

--- a/src/main/java/xiao/battleroyale/client/game/data/ClientGameData.java
+++ b/src/main/java/xiao/battleroyale/client/game/data/ClientGameData.java
@@ -2,15 +2,27 @@ package xiao.battleroyale.client.game.data;
 
 import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.NotNull;
+import xiao.battleroyale.BattleRoyale;
 import xiao.battleroyale.api.message.game.GameTag;
 import xiao.battleroyale.client.game.ClientGameDataManager;
 import xiao.battleroyale.common.message.game.GameMessageManager;
+import xiao.battleroyale.common.message.game.SpectateMessageManager;
+import xiao.battleroyale.util.ColorUtils;
+
+import java.awt.*;
+import java.util.HashMap;
+import java.util.UUID;
 
 public class ClientGameData extends AbstractClientExpireData {
 
-    public int standingPlayerCount = 0;
+    private int standingPlayerCount = 0;
+    public int standingPlayerCount() { return standingPlayerCount; }
+    private UUID gameId = UUID.randomUUID();
+    public UUID gameId() { return gameId; }
     private boolean inGame;
     public boolean inGame() { return inGame; }
+    private final ClientSpectateData spectateData = new ClientSpectateData();
+    public ClientSpectateData getSpectateData() { return spectateData; }
     // TODO 待更新区域进度条显示？
 
     public ClientGameData() {
@@ -26,11 +38,52 @@ public class ClientGameData extends AbstractClientExpireData {
 
         this.standingPlayerCount = messageNbt.getCompound(GameMessageManager.ALIVE_KEY).getInt(GameTag.ALIVE);
         this.inGame = standingPlayerCount > 0;
+        if (this.inGame) {
+            if (messageNbt.contains(GameMessageManager.GAMEID_KEY)) {
+                UUID newGameId = messageNbt.getUUID(GameMessageManager.GAMEID_KEY);
+                if (!newGameId.equals(this.gameId)) {
+                    this.spectateData.clear();
+                }
+                this.gameId = newGameId;
+            }
+        } else {
+            this.spectateData.clear();
+        }
+
         this.lastUpdateTick = ClientGameDataManager.getCurrentTick();
     }
 
     public void clear() {
         this.standingPlayerCount = 0;
         this.inGame = false;
+        this.spectateData.clear();
+    }
+
+    public static class ClientSpectateData extends AbstractClientExpireData {
+
+        HashMap<UUID, Color> uuidToColor = new HashMap<>();
+
+        @Override
+        public void updateFromNbt(@NotNull CompoundTag messageNbt) {
+            this.lastMessageNbt = messageNbt;
+            BattleRoyale.LOGGER.debug("Received spectate message nbt:{}", messageNbt);
+
+            // 不自动清理，由GameData的消息状况处理清理
+            CompoundTag spectateTags = messageNbt.getCompound(SpectateMessageManager.SPECTATE_KEY);
+            for (String key : spectateTags.getAllKeys()) {
+                UUID playerUUID = UUID.fromString(key);
+                Color color = ColorUtils.parseColorFromString(spectateTags.getString(key));
+                uuidToColor.put(playerUUID, color);
+            }
+
+            for (UUID key : uuidToColor.keySet()) {
+                BattleRoyale.LOGGER.debug("key:{}, value:{}", key, uuidToColor.get(key));
+            }
+        }
+
+        public void clear() {
+            uuidToColor.clear();
+            BattleRoyale.LOGGER.debug("uuidToColor.clear()");
+        }
     }
 }

--- a/src/main/java/xiao/battleroyale/client/renderer/CustomRenderType.java
+++ b/src/main/java/xiao/battleroyale/client/renderer/CustomRenderType.java
@@ -13,10 +13,10 @@ import xiao.battleroyale.BattleRoyale;
 public class CustomRenderType {
 
     private static final ResourceLocation WHITE_TEXTURE = new ResourceLocation(BattleRoyale.MOD_ID, "textures/white.png");
-    public static final RenderType SolidTranslucentColor = createZoneTranslucent();
-    public static final RenderType SolidOpaqueColor = createZoneOpaque();
+    public static final RenderType SolidTranslucentColor = createSolidTranslucent();
+    public static final RenderType SolidOpaqueColor = createSolidOpaque();
 
-    private static RenderType createZoneTranslucent() {
+    private static RenderType createSolidTranslucent() {
         RenderStateShard.TransparencyStateShard translucent = new RenderStateShard.TransparencyStateShard(
                 "zone_translucent",
                 () -> {
@@ -61,7 +61,7 @@ public class CustomRenderType {
         );
     }
 
-    private static RenderType createZoneOpaque() {
+    private static RenderType createSolidOpaque() {
         RenderStateShard.TransparencyStateShard noBlend = new RenderStateShard.TransparencyStateShard(
                 "zone_opaque",
                 RenderSystem::disableBlend,

--- a/src/main/java/xiao/battleroyale/client/renderer/CustomRenderType.java
+++ b/src/main/java/xiao/battleroyale/client/renderer/CustomRenderType.java
@@ -18,7 +18,7 @@ public class CustomRenderType {
 
     private static RenderType createSolidTranslucent() {
         RenderStateShard.TransparencyStateShard translucent = new RenderStateShard.TransparencyStateShard(
-                "zone_translucent",
+                "solid_translucent",
                 () -> {
                     RenderSystem.enableBlend();
                     GlStateManager._blendFuncSeparate(
@@ -51,7 +51,7 @@ public class CustomRenderType {
                 .createCompositeState(true);
 
         return RenderType.create(
-                "zone_translucent",
+                "solid_translucent",
                 DefaultVertexFormat.POSITION_COLOR,
                 VertexFormat.Mode.QUADS,
                 256,
@@ -63,7 +63,7 @@ public class CustomRenderType {
 
     private static RenderType createSolidOpaque() {
         RenderStateShard.TransparencyStateShard noBlend = new RenderStateShard.TransparencyStateShard(
-                "zone_opaque",
+                "solid_opaque",
                 RenderSystem::disableBlend,
                 () -> {}
         );
@@ -84,7 +84,7 @@ public class CustomRenderType {
                 .createCompositeState(true);
 
         return RenderType.create(
-                "zone_opaque",
+                "solid_opaque",
                 DefaultVertexFormat.POSITION_COLOR,
                 VertexFormat.Mode.QUADS,
                 256,

--- a/src/main/java/xiao/battleroyale/client/renderer/game/GameInfoRenderer.java
+++ b/src/main/java/xiao/battleroyale/client/renderer/game/GameInfoRenderer.java
@@ -73,7 +73,7 @@ public class GameInfoRenderer {
         // 生存: {人数}
         ClientGameData gameData = ClientGameDataManager.get().getGameData();
         if (gameData.inGame()) {
-            renderAliveTotal(posX, posY, gameData.standingPlayerCount, guiGraphics, fontRenderer);
+            renderAliveTotal(posX, posY, gameData.standingPlayerCount(), guiGraphics, fontRenderer);
         }
     }
 

--- a/src/main/java/xiao/battleroyale/client/renderer/game/SpectatePlayerRenderer.java
+++ b/src/main/java/xiao/battleroyale/client/renderer/game/SpectatePlayerRenderer.java
@@ -47,7 +47,7 @@ public class SpectatePlayerRenderer {
         registered = false;
     }
 
-    private static final RenderType SPECTATE_BEAM_RENDER_TYPE = CustomRenderType.SolidTranslucentColor;
+    private static final RenderType SPECTATE_PLAYER_RENDER_TYPE = CustomRenderType.SolidTranslucentColor;
     private static boolean enableSpectateRender = true;
     public static void setEnableSpectateRender(boolean bool) { enableSpectateRender = bool; }
     private static boolean useClientColor = false;
@@ -98,15 +98,7 @@ public class SpectatePlayerRenderer {
     }
 
     public void onRenderLevelStage(RenderLevelStageEvent event) {
-        if (!enableSpectateRender ) {
-            return;
-        }
-        boolean renderNoDepth;
-        if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
-            renderNoDepth = false;
-        } else if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_LEVEL) {
-            renderNoDepth = true;
-        } else {
+        if (!enableSpectateRender || event.getStage() != RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
             return;
         }
 
@@ -125,7 +117,7 @@ public class SpectatePlayerRenderer {
         Vec3 cameraPos = event.getCamera().getPosition();
         float partialTicks = event.getPartialTick();
 
-        VertexConsumer consumer = bufferSource.getBuffer(SPECTATE_BEAM_RENDER_TYPE);
+        VertexConsumer consumer = bufferSource.getBuffer(SPECTATE_PLAYER_RENDER_TYPE);
 
         int worldMaxBuildHeight = mc.level.getMaxBuildHeight();
 

--- a/src/main/java/xiao/battleroyale/client/renderer/game/SpectatePlayerRenderer.java
+++ b/src/main/java/xiao/battleroyale/client/renderer/game/SpectatePlayerRenderer.java
@@ -1,0 +1,195 @@
+package xiao.battleroyale.client.renderer.game;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.client.event.RenderLevelStageEvent;
+import net.minecraftforge.common.MinecraftForge;
+import xiao.battleroyale.BattleRoyale;
+import xiao.battleroyale.client.game.ClientGameDataManager;
+import xiao.battleroyale.client.game.data.ClientGameData.ClientSpectateData;
+import xiao.battleroyale.client.renderer.CustomRenderType;
+import xiao.battleroyale.util.ClassUtils;
+import xiao.battleroyale.util.ColorUtils;
+
+import java.awt.*;
+import java.util.UUID;
+
+public class SpectatePlayerRenderer {
+
+    private static class SpectatePlayerRendererHolder {
+        private static final SpectatePlayerRenderer INSTANCE = new SpectatePlayerRenderer();
+    }
+
+    public static SpectatePlayerRenderer get() {
+        return SpectatePlayerRendererHolder.INSTANCE;
+    }
+
+    private SpectatePlayerRenderer() {}
+
+    private static boolean registered = false;
+    public static boolean isRegistered() {
+        return registered;
+    }
+
+    public static void register() {
+        MinecraftForge.EVENT_BUS.register(get());
+        registered = true;
+    }
+
+    public static void unregister() {
+        MinecraftForge.EVENT_BUS.unregister(get());
+        registered = false;
+    }
+
+    private static final RenderType SPECTATE_BEAM_RENDER_TYPE = CustomRenderType.SolidTranslucentColor;
+    private static boolean enableSpectateRender = true;
+    public static void setEnableSpectateRender(boolean bool) { enableSpectateRender = bool; }
+    private static boolean useClientColor = false;
+    public static void setUseClientColor(boolean use) { useClientColor = use; }
+    private static String clientColorString = "#00FFFF77";
+    private static float R = 0f;
+    private static float G = 1f;
+    private static float B = 1f;
+    public static void setClientColorString(String colorString) {
+        clientColorString = colorString;
+        Color color = ColorUtils.parseColorFromString(colorString);
+        R = color.getRed() / 255.0F;
+        G = color.getGreen() / 255.0F;
+        B = color.getBlue() / 255.0F;
+        BattleRoyale.LOGGER.debug("SpectatePlayerRenderer R{} G{} B{}", R, G, B);
+    }
+    private static boolean renderBeacon = true;
+    public static void setRenderBeacon(boolean bool) { renderBeacon = bool; }
+    private static boolean renderBoundingBox = true;
+    public static void setRenderBoundingBox(boolean bool) { renderBoundingBox = bool; }
+    private static float A = 0.5F;
+    public static void setTransparency(float a) { A = a; }
+
+    private static ClassUtils.ArraySet<UUID> cachedSpectatePlayerUUID = new ClassUtils.ArraySet<>();
+    private static int scanFrequency = 20 * 3; // 3秒扫一次
+    public static void setScanFrequency(int frequency) { scanFrequency = frequency; }
+    public static int getScanFrequency() { return scanFrequency; }
+
+    public void scanSpectatePlayers() {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.level == null || mc.player == null) {
+            return;
+        }
+
+        ClientSpectateData spectateData = ClientGameDataManager.get().getGameData().getSpectateData();
+        if (spectateData.uuidToColor.isEmpty()) {
+            return;
+        }
+
+        cachedSpectatePlayerUUID.clear();
+        for (UUID uuid : spectateData.uuidToColor.keySet()) {
+            Player spectatePlayer = mc.level.getPlayerByUUID(uuid);
+            if (spectatePlayer != null
+                    && !spectatePlayer.getUUID().equals(mc.player.getUUID())) { // 不渲染自己，会挡住第一人称
+                cachedSpectatePlayerUUID.add(uuid);
+            }
+        }
+    }
+
+    public void onRenderLevelStage(RenderLevelStageEvent event) {
+        if (!enableSpectateRender ) {
+            return;
+        }
+        boolean renderNoDepth;
+        if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
+            renderNoDepth = false;
+        } else if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_LEVEL) {
+            renderNoDepth = true;
+        } else {
+            return;
+        }
+
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.level == null || mc.player == null || !mc.player.isSpectator()) {
+            return;
+        }
+
+        ClientSpectateData spectateData = ClientGameDataManager.get().getGameData().getSpectateData();
+        if (spectateData.uuidToColor.isEmpty()) {
+            return;
+        }
+
+        PoseStack poseStack = event.getPoseStack();
+        MultiBufferSource.BufferSource bufferSource = mc.renderBuffers().bufferSource();
+        Vec3 cameraPos = event.getCamera().getPosition();
+        float partialTicks = event.getPartialTick();
+
+        VertexConsumer consumer = bufferSource.getBuffer(SPECTATE_BEAM_RENDER_TYPE);
+
+        int worldMaxBuildHeight = mc.level.getMaxBuildHeight();
+
+        float r, g, b, a = A;
+        for (UUID uuid : cachedSpectatePlayerUUID) {
+            ClientSpectateData.UUIDrgb uuidRGB = spectateData.uuidToColor.mapGet(uuid);
+            if (uuidRGB == null) { // 不立即更新spectateData
+                continue;
+            }
+            Player spectatePlayer = mc.level.getPlayerByUUID(uuid);
+            if (spectatePlayer == null) { // 不立即更新cachedSpectatePlayerUUID
+                continue;
+            }
+
+            // 颜色
+            if (useClientColor) {
+                r = R;
+                g = G;
+                b = B;
+            } else {
+                r = uuidRGB.r();
+                g = uuidRGB.g();
+                b = uuidRGB.b();
+            }
+
+            // 渲染
+            Vec3 lastTickPos = new Vec3(spectatePlayer.xOld, spectatePlayer.yOld, spectatePlayer.zOld);
+            Vec3 currentTickPos = spectatePlayer.position();
+            Vec3 interpolatedPos = lastTickPos.lerp(currentTickPos, partialTicks);
+            AABB boundingBox = spectatePlayer.getBoundingBox();
+            float playerHeight = (float) (boundingBox.maxY - boundingBox.minY);
+            float baseWidth = (float) (boundingBox.maxX - boundingBox.minX);
+            float baseDepth = (float) (boundingBox.maxZ - boundingBox.minZ);
+
+            float cylinderHeight = (float) (worldMaxBuildHeight - interpolatedPos.y - playerHeight);
+
+            poseStack.pushPose();
+            try {
+                // 将坐标系的原点平移到玩家的脚底中心
+                poseStack.translate(interpolatedPos.x - cameraPos.x,
+                        interpolatedPos.y - cameraPos.y,
+                        interpolatedPos.z - cameraPos.z);
+                if (renderBoundingBox) {
+                    // 渲染长方体
+                    poseStack.pushPose();
+                    // 向上平移长方体高度的一半，使其中心与玩家身体中心对齐
+                    poseStack.translate(0, playerHeight / 2.0F, 0);
+                    Shape3D.drawFilledCuboid(poseStack, consumer, r, g, b, a,
+                            baseWidth / 2.0F, playerHeight / 2.0F, baseDepth / 2.0F);
+                    poseStack.popPose();
+                }
+                if (renderBeacon) {
+                    // 渲染圆柱体
+                    poseStack.pushPose();
+                    // 向上平移到长方体的顶部
+                    poseStack.translate(0, playerHeight, 0);
+                    Shape2D.drawFilledPolygonCylinder(poseStack, consumer, r, g, b, a,
+                            baseWidth / 2.0F, cylinderHeight, 16, 0);
+                    poseStack.popPose();
+                }
+            } finally {
+                poseStack.popPose();
+            }
+        }
+        bufferSource.endBatch();
+    }
+}

--- a/src/main/java/xiao/battleroyale/client/renderer/game/SpectatePlayerRenderer.java
+++ b/src/main/java/xiao/battleroyale/client/renderer/game/SpectatePlayerRenderer.java
@@ -52,28 +52,26 @@ public class SpectatePlayerRenderer {
     public static void setEnableSpectateRender(boolean bool) { enableSpectateRender = bool; }
     private static boolean useClientColor = false;
     public static void setUseClientColor(boolean use) { useClientColor = use; }
-    private static String clientColorString = "#00FFFF77";
     private static float R = 0f;
     private static float G = 1f;
     private static float B = 1f;
     public static void setClientColorString(String colorString) {
-        clientColorString = colorString;
         Color color = ColorUtils.parseColorFromString(colorString);
         R = color.getRed() / 255.0F;
         G = color.getGreen() / 255.0F;
         B = color.getBlue() / 255.0F;
-        BattleRoyale.LOGGER.debug("SpectatePlayerRenderer R{} G{} B{}", R, G, B);
+        BattleRoyale.LOGGER.debug("SpectatePlayerRenderer {} R{} G{} B{}", colorString, R, G, B);
     }
     private static boolean renderBeacon = true;
     public static void setRenderBeacon(boolean bool) { renderBeacon = bool; }
     private static boolean renderBoundingBox = true;
     public static void setRenderBoundingBox(boolean bool) { renderBoundingBox = bool; }
     private static float A = 0.5F;
-    public static void setTransparency(float a) { A = a; }
+    public static void setTransparency(float a) { A = Math.min(Math.max(0, a), 1); }
 
-    private static ClassUtils.ArraySet<UUID> cachedSpectatePlayerUUID = new ClassUtils.ArraySet<>();
+    private static final ClassUtils.ArraySet<UUID> cachedSpectatePlayerUUID = new ClassUtils.ArraySet<>();
     private static int scanFrequency = 20 * 3; // 3秒扫一次
-    public static void setScanFrequency(int frequency) { scanFrequency = frequency; }
+    public static void setScanFrequency(int frequency) { scanFrequency = Math.max(frequency, 1); }
     public static int getScanFrequency() { return scanFrequency; }
 
     public void scanSpectatePlayers() {

--- a/src/main/java/xiao/battleroyale/client/renderer/game/TeamInfoRenderer.java
+++ b/src/main/java/xiao/battleroyale/client/renderer/game/TeamInfoRenderer.java
@@ -105,7 +105,7 @@ public class TeamInfoRenderer {
             [id] playerName
             ---------------（血条）
              */
-            guiGraphics.drawString(fontRenderer, playerId, posX, currentY, idColor, false); // false表示不带阴影
+            guiGraphics.drawString(fontRenderer, playerId, posX, currentY, idColor, true); // 个别颜色不带阴影看不见
             guiGraphics.drawString(fontRenderer, playerName, posX + fontRenderer.width(playerId) + 1, currentY, nameColor, true);
             boolean alive = memberInfo.alive;
             int healthStartY = currentY + HEALTH_OFFSET; // 血条左上角

--- a/src/main/java/xiao/battleroyale/client/renderer/game/TeamMemberRenderer.java
+++ b/src/main/java/xiao/battleroyale/client/renderer/game/TeamMemberRenderer.java
@@ -5,7 +5,6 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
@@ -54,17 +53,15 @@ public class TeamMemberRenderer {
     public static void setEnableTeamZone(boolean bool) { enableTeamZone = bool; }
     private static boolean useClientColor = false;
     public static void setUseClientColor(boolean use) { useClientColor = use; }
-    private static String clientColorString = "#00FFFF77";
     private static float R = 0f;
     private static float G = 1f;
     private static float B = 1f;
     public static void setClientColorString(String colorString) {
-        clientColorString = colorString;
         Color color = ColorUtils.parseColorFromString(colorString);
         R = color.getRed() / 255.0F;
         G = color.getGreen() / 255.0F;
         B = color.getBlue() / 255.0F;
-        BattleRoyale.LOGGER.debug("TeamZoneRender R{} G{} B{}", R, G, B);
+        BattleRoyale.LOGGER.debug("TeamZoneRender {} R{} G{} B{}", colorString, R, G, B);
     }
     private static boolean renderBeacon = true;
     public static void setRenderBeacon(boolean bool) { renderBeacon = bool; }

--- a/src/main/java/xiao/battleroyale/client/renderer/game/TeamMemberRenderer.java
+++ b/src/main/java/xiao/battleroyale/client/renderer/game/TeamMemberRenderer.java
@@ -6,6 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
@@ -116,14 +117,13 @@ public class TeamMemberRenderer {
                 continue;
             }
 
-            Entity teammateEntity = mc.level.getPlayerByUUID(member.uuid);
-            if (teammateEntity != null) {
-                AABB boundingBox = teammateEntity.getBoundingBox();
-
-                Vec3 lastTickPos = new Vec3(teammateEntity.xOld, teammateEntity.yOld, teammateEntity.zOld);
-                Vec3 currentTickPos = teammateEntity.position();
+            Player teammatePlayer = mc.level.getPlayerByUUID(member.uuid);
+            if (teammatePlayer != null) {
+                // 渲染
+                Vec3 lastTickPos = new Vec3(teammatePlayer.xOld, teammatePlayer.yOld, teammatePlayer.zOld);
+                Vec3 currentTickPos = teammatePlayer.position();
                 Vec3 interpolatedPos = lastTickPos.lerp(currentTickPos, partialTicks);
-
+                AABB boundingBox = teammatePlayer.getBoundingBox();
                 float teammateHeight = (float) (boundingBox.maxY - boundingBox.minY);
                 float baseWidth = (float) (boundingBox.maxX - boundingBox.minX);
                 float baseDepth = (float) (boundingBox.maxZ - boundingBox.minZ);

--- a/src/main/java/xiao/battleroyale/command/sub/GameCommand.java
+++ b/src/main/java/xiao/battleroyale/command/sub/GameCommand.java
@@ -210,7 +210,8 @@ public class GameCommand {
         CommandSourceStack source = context.getSource();
         ServerPlayer player = source.getPlayerOrException();
 
-        if (GameManager.get().spectateGame(player, source.getLevel())) {
+        if (GameManager.get().spectateGame(player)) {
+            source.sendSuccess(() -> Component.translatable("battleroyale.message.switch_gamemode_success"), false);
             return Command.SINGLE_SUCCESS;
         } else {
             source.sendFailure(Component.translatable("battleroyale.message.switch_gamemode_failed"));

--- a/src/main/java/xiao/battleroyale/command/sub/TeamCommand.java
+++ b/src/main/java/xiao/battleroyale/command/sub/TeamCommand.java
@@ -123,7 +123,7 @@ public class TeamCommand {
     private static int requestPlayer(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         ServerPlayer sender = context.getSource().getPlayerOrException();
         ServerPlayer targetPlayer = EntityArgument.getPlayer(context, PLAYER);
-        TeamManager.get().RequestPlayer(sender, targetPlayer);
+        TeamManager.get().requestPlayer(sender, targetPlayer);
         return Command.SINGLE_SUCCESS;
     }
 

--- a/src/main/java/xiao/battleroyale/common/game/GameManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/GameManager.java
@@ -715,8 +715,8 @@ public class GameManager extends AbstractGameManager implements IStatsWriter {
 
     public void onPlayerLoggedOut(ServerPlayer player) {
         if (!isInGame()) {
-            if (TeamManager.get().removePlayerFromTeam(player.getUUID())) { // 没开始游戏就等于离队
-                BattleRoyale.LOGGER.debug("Player {} logged out, remove GamePlayer", player.getName().getString());
+            if (TeamManager.get().leaveTeam(player)) { // 没开始游戏就等于离队
+                BattleRoyale.LOGGER.debug("Player {} logged out, leave GamePlayer", player.getName().getString());
             }
         }
 

--- a/src/main/java/xiao/battleroyale/common/game/GameManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/GameManager.java
@@ -252,7 +252,7 @@ public class GameManager extends AbstractGameManager implements IStatsWriter {
         SpawnManager.get().onGameTick(gameTime);
         // StatsManager.get().onGameTick(gameTime); // 基于事件主动记录，不用tick
         if (gameTime % 200 == 0) {
-            finishGameIfShouldEnd();
+            finishGameIfShouldEnd(); // 每10秒保底检查游戏结束
         }
     }
 
@@ -342,10 +342,18 @@ public class GameManager extends AbstractGameManager implements IStatsWriter {
         }
     }
     private void notifyGamePlayerIsInactive(GamePlayer gamePlayer) {
-        ChatUtils.sendComponentMessageToAllPlayers(serverLevel, Component.translatable("battleroyale.message.player_leaved_from_level", gamePlayer.getPlayerName()).withStyle(ChatFormatting.DARK_GRAY));
+        if (this.serverLevel != null) {
+            ChatUtils.sendComponentMessageToAllPlayers(serverLevel, Component.translatable("battleroyale.message.player_leaved_from_level", gamePlayer.getPlayerName()).withStyle(ChatFormatting.DARK_GRAY));
+        } else {
+            BattleRoyale.LOGGER.warn("GameManager.serverLevel is null in notifyGamePlayerIsInactive(GamePlayer {})", gamePlayer.getPlayerName());
+        }
     }
     private void notifyGamePlayerIsActive(GamePlayer gamePlayer) {
-        ChatUtils.sendComponentMessageToAllPlayers(serverLevel, Component.translatable("battleroyale.message.player_backed_to_level", gamePlayer.getPlayerName()).withStyle(ChatFormatting.DARK_GRAY));
+        if (this.serverLevel != null) {
+            ChatUtils.sendComponentMessageToAllPlayers(serverLevel, Component.translatable("battleroyale.message.player_backed_to_level", gamePlayer.getPlayerName()).withStyle(ChatFormatting.DARK_GRAY));
+        } else {
+            BattleRoyale.LOGGER.warn("GameManager.serverLevel is null in notifyGamePlayerIsActive(GamePlayer {})", gamePlayer.getPlayerName());
+        }
     }
 
     /**
@@ -430,7 +438,7 @@ public class GameManager extends AbstractGameManager implements IStatsWriter {
         }
 
         checkAndUpdateInvalidGamePlayer(this.serverLevel);
-        finishGameIfShouldEnd();
+        finishGameIfShouldEnd(); // 外部调用的检查
     }
 
     private void finishGameIfShouldEnd() {
@@ -498,6 +506,11 @@ public class GameManager extends AbstractGameManager implements IStatsWriter {
             }
             if (serverLevel != null) {
                 ChatUtils.sendMessageToAllPlayers(serverLevel, winnerComponent);
+            }
+
+            // 游戏正常结束后自动初始化游戏
+            if (this.gameEntry.initGameAfterGame) {
+                initGame(this.serverLevel);
             }
         }
     }
@@ -680,7 +693,7 @@ public class GameManager extends AbstractGameManager implements IStatsWriter {
         GamePlayer gamePlayer = TeamManager.get().getGamePlayerByUUID(player.getUUID());
         if (gamePlayer != null) {
             gamePlayer.setActiveEntity(false);
-            finishGameIfShouldEnd();
+            finishGameIfShouldEnd(); // 玩家登出服务器时的防御检查
         }
     }
 
@@ -781,7 +794,7 @@ public class GameManager extends AbstractGameManager implements IStatsWriter {
                     BattleRoyale.LOGGER.debug("Team {} has already been eliminated, GameManager skipped sending chat message", gameTeam.getGameTeamId());
                 }
             }
-            finishGameIfShouldEnd();
+            finishGameIfShouldEnd(); // 游戏队伍被淘汰时的检查
         }
         notifyTeamChange(gamePlayer.getGameTeamId());
         notifyAliveChange();

--- a/src/main/java/xiao/battleroyale/common/game/GameManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/GameManager.java
@@ -1196,7 +1196,9 @@ public class GameManager extends AbstractGameManager implements IStatsWriter {
                 }
                 player.setGameMode(GameType.SPECTATOR);
                 teleportToRandomStandingGamePlayer(player);
-                MessageManager.get().notifySpectateChange(gamePlayer.getGameSingleId());
+                if (this.gameEntry.spectatorSeeAllTeams) {
+                    MessageManager.get().notifySpectateChange(gamePlayer.getGameSingleId());
+                }
                 return true;
             } else if (!this.gameEntry.onlyGamePlayerSpectate){ // 非游戏玩家能观战
                 player.setGameMode(GameType.SPECTATOR);

--- a/src/main/java/xiao/battleroyale/common/game/GameManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/GameManager.java
@@ -980,13 +980,21 @@ public class GameManager extends AbstractGameManager implements IStatsWriter {
     private boolean initGameConfigSetup() {
         GameruleConfig gameruleConfig = GameConfigManager.get().getGameruleConfig(gameruleConfigId);
         if (gameruleConfig == null) {
-            ChatUtils.sendTranslatableMessageToAllPlayers(serverLevel, "battleroyale.message.missing_gamerule_config");
+            if (this.serverLevel != null) {
+                ChatUtils.sendTranslatableMessageToAllPlayers(this.serverLevel, "battleroyale.message.missing_gamerule_config");
+            } else {
+                BattleRoyale.LOGGER.error("GameManager.serverLevel is null in initGameConfigSetup: gameruleConfig == null");
+            }
             return false;
         }
         BattleroyaleEntry brEntry = gameruleConfig.getBattleRoyaleEntry();
         GameEntry gameEntry = gameruleConfig.getGameEntry();
         if (brEntry == null || gameEntry == null) {
-            ChatUtils.sendTranslatableMessageToAllPlayers(serverLevel, "battleroyale.message.missing_gamerule_config");
+            if (this.serverLevel != null) {
+                ChatUtils.sendTranslatableMessageToAllPlayers(this.serverLevel, "battleroyale.message.missing_gamerule_config");
+            } else {
+                BattleRoyale.LOGGER.error("GameManager.serverLevel is null in initGameConfigSetup: brEntry == null || gameEntry == null");
+            }
             return false;
         }
         this.maxGameTime = brEntry.maxGameTime;

--- a/src/main/java/xiao/battleroyale/common/game/gamerule/storage/McRuleStorage.java
+++ b/src/main/java/xiao/battleroyale/common/game/gamerule/storage/McRuleStorage.java
@@ -71,7 +71,7 @@ public class McRuleStorage implements IRuleStorage {
                 serverLevel.getGameRules().getRule(GameRules.RULE_SPECTATORSGENERATECHUNKS).get(),
                 serverLevel.getGameRules().getRule(GameRules.RULE_KEEPINVENTORY).get(),
                 mcEntry.doTimeSet,
-                serverLevel.getGameTime() // 当前总游戏刻
+                serverLevel.getDayTime()
                 );
     }
 

--- a/src/main/java/xiao/battleroyale/common/game/spawn/SpawnManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/spawn/SpawnManager.java
@@ -17,6 +17,7 @@ import xiao.battleroyale.compat.playerrevive.PlayerRevive;
 import xiao.battleroyale.config.common.game.GameConfigManager;
 import xiao.battleroyale.config.common.game.gamerule.GameruleConfigManager.GameruleConfig;
 import xiao.battleroyale.config.common.game.gamerule.type.BattleroyaleEntry;
+import xiao.battleroyale.config.common.game.gamerule.type.GameEntry;
 import xiao.battleroyale.config.common.game.spawn.SpawnConfigManager.SpawnConfig;
 import xiao.battleroyale.event.game.LobbyEventHandler;
 import xiao.battleroyale.util.ChatUtils;
@@ -44,6 +45,7 @@ public class SpawnManager extends AbstractGameManager {
         ;
     }
 
+    private boolean initGameTeleport = true;
     private Vec3 lobbyPos;
     private Vec3 lobbyDimension;
     private boolean lobbyMuteki = true;
@@ -88,6 +90,15 @@ public class SpawnManager extends AbstractGameManager {
             return;
         }
 
+        GameEntry gameEntry = gameruleConfig.getGameEntry();
+        if (gameEntry == null) {
+            BattleRoyale.LOGGER.debug("Gamerule config missing gameEntry");
+            ChatUtils.sendTranslatableMessageToAllPlayers(serverLevel, "battleroyale.message.missing_gamerule_config");
+            return;
+        }
+        this.initGameTeleport = gameEntry.teleportWhenInitGame;
+
+
         this.configPrepared = true;
         BattleRoyale.LOGGER.debug("SpawnManager complete initGameConfig");
     }
@@ -102,9 +113,12 @@ public class SpawnManager extends AbstractGameManager {
         }
 
         // 传送至大厅
-        List<GamePlayer> gamePlayerList = GameManager.get().getGamePlayers();
-        for (GamePlayer gamePlayer : gamePlayerList) {
-            teleportGamePlayerToLobby(gamePlayer, serverLevel);
+        if (this.initGameTeleport) {
+            List<GamePlayer> gamePlayerList = GameManager.get().getGamePlayers();
+            for (GamePlayer gamePlayer : gamePlayerList) {
+                teleportGamePlayerToLobby(gamePlayer, serverLevel);
+            }
+            BattleRoyale.LOGGER.debug("SpawnManager::initGame teleported all game player to lobby");
         }
 
         this.gameSpawner.clear();

--- a/src/main/java/xiao/battleroyale/common/game/spawn/SpawnManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/spawn/SpawnManager.java
@@ -146,7 +146,6 @@ public class SpawnManager extends AbstractGameManager {
 
     @Override
     public void stopGame(@Nullable ServerLevel serverLevel) {
-        LobbyEventHandler.unregister();
         this.configPrepared = false;
         // this.ready = false; // isReady被重载
     }

--- a/src/main/java/xiao/battleroyale/common/game/spawn/SpawnManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/spawn/SpawnManager.java
@@ -77,20 +77,17 @@ public class SpawnManager extends AbstractGameManager {
         }
 
         BattleroyaleEntry brEntry = gameruleConfig.getBattleRoyaleEntry();
-        this.lobbyPos = brEntry.lobbyCenterPos;
-        this.lobbyDimension = brEntry.lobbyDimension;
-        this.lobbyMuteki = brEntry.lobbyMuteki;
-        if (lobbyPos == null || lobbyDimension == null) {
+        if (brEntry == null) {
+            BattleRoyale.LOGGER.debug("Gamerule config missing brEntry");
+            ChatUtils.sendTranslatableMessageToAllPlayers(serverLevel, "battleroyale.message.missing_gamerule_config");
+            return;
+        }
+        setLobby(brEntry.lobbyCenterPos, brEntry.lobbyDimension, brEntry.lobbyMuteki, brEntry.lobbyHeal, brEntry.lobbyChangeGamemode);
+        if (!isLobbyCreated()) {
             ChatUtils.sendTranslatableMessageToAllPlayers(serverLevel, "battleroyale.message.missing_gamerule_config");
             return;
         }
 
-        // Hyper Muteki的大厅
-        if (this.lobbyMuteki) {
-            LobbyEventHandler.register();
-        } else {
-            LobbyEventHandler.unregister();
-        }
         this.configPrepared = true;
         BattleRoyale.LOGGER.debug("SpawnManager complete initGameConfig");
     }
@@ -268,6 +265,12 @@ public class SpawnManager extends AbstractGameManager {
         }
         this.lobbyPos = centerPos;
         this.lobbyMuteki = shouldMuteki;
+        // 大厅无敌（监听伤害事件）
+        if (this.lobbyMuteki) {
+            LobbyEventHandler.register();
+        } else {
+            LobbyEventHandler.unregister();
+        }
         this.lobbyHeal = shouldHeal;
         this.lobbyDimension = dimension;
         this.changeGamemode = changeGamemode;
@@ -287,8 +290,7 @@ public class SpawnManager extends AbstractGameManager {
             BattleRoyale.LOGGER.warn("SpawnManager: radius:{} has negative, reject to apply", radius);
             return false;
         }
-        this.lobbyPos = centerPos;
-        this.lobbyDimension = new Vec3(radius, radius, radius);
+        setLobby(centerPos, new Vec3(radius, radius, radius), this.lobbyMuteki, this.lobbyHeal, this.changeGamemode);
         return true;
     }
 }

--- a/src/main/java/xiao/battleroyale/common/game/team/GameTeam.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/GameTeam.java
@@ -146,6 +146,7 @@ public class GameTeam {
     }
 
     public String getVanillaTeamName() {
+        // 不合法的队伍名（无法解析字符串，空格会导致后面的部分视为参数），天然避免了对原版队伍内规则的修改
         return String.format("CBR Team %s", this.gameTeamId);
     }
 }

--- a/src/main/java/xiao/battleroyale/common/game/team/GameTeam.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/GameTeam.java
@@ -144,4 +144,8 @@ public class GameTeam {
         return teamMembers.stream()
                 .allMatch(gamePlayer -> gamePlayer.isBot() || (!gamePlayer.isBot() && gamePlayer.isEliminated()));
     }
+
+    public String getVanillaTeamName() {
+        return String.format("CBR Team %s", this.gameTeamId);
+    }
 }

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamConfig.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamConfig.java
@@ -41,7 +41,7 @@ public class TeamConfig implements IStatsWriter {
         if (teamColors.isEmpty()) {
             return "#FFFFFFFF";
         } else {
-            return teamColors.get(teamId % teamColors.size());
+            return teamColors.get((teamId - 1) % teamColors.size()); // teamId从1开始
         }
     }
 

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamData.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamData.java
@@ -197,6 +197,9 @@ public class TeamData extends AbstractGameManagerData {
         return true;
     }
 
+    /**
+     * 使GamePlayer失效，调用后应不再使用传入的GamePlayer
+     */
     public boolean removePlayer(GamePlayer player) {
         if (locked) {
             return false;
@@ -205,6 +208,9 @@ public class TeamData extends AbstractGameManagerData {
         return removePlayer(player.getPlayerUUID());
     }
 
+    /**
+     * 使UUID对应的GamePlayer失效，调用后应不再使用对应的GamePlayer
+     */
     public boolean removePlayer(UUID playerId) {
         if (locked) {
             return false;

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamExternal.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamExternal.java
@@ -7,7 +7,6 @@ import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.scores.Scoreboard;
 import org.jetbrains.annotations.NotNull;
 import xiao.battleroyale.BattleRoyale;
 import xiao.battleroyale.command.sub.TeamCommand;
@@ -357,18 +356,6 @@ public class TeamExternal {
 
         if (teamManager.removePlayerFromTeam(playerUUID)) { // 不在游戏时生效，手动离开当前队伍
             ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.leaved_current_team").withStyle(ChatFormatting.GREEN));
-
-            // 移除原版Team
-            ServerLevel serverLevel = GameManager.get().getServerLevel();
-            if (serverLevel != null) {
-                Scoreboard scoreboard = serverLevel.getScoreboard();
-                if (GameManager.get().getGameEntry().buildVanillaTeam) {
-                    String playerName = player.getName().getString();
-                    scoreboard.removePlayerFromTeam(playerName);
-                }
-            } else {
-                BattleRoyale.LOGGER.debug("GameManager.serverLevel is null in TeamExternal::leaveTeam, skipped leave vanilal team");
-            }
         }
         return teamManager.getGamePlayerByUUID(playerUUID) == null;
     }

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamExternal.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamExternal.java
@@ -1,0 +1,385 @@
+package xiao.battleroyale.common.game.team;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import xiao.battleroyale.BattleRoyale;
+import xiao.battleroyale.command.sub.TeamCommand;
+import xiao.battleroyale.common.game.GameManager;
+import xiao.battleroyale.util.ChatUtils;
+
+import java.util.UUID;
+
+public class TeamExternal {
+
+    /**
+     * 玩家加入游戏，优先创建队伍，无法创建队伍则发送申请
+     * @param player 需要加入队伍的玩家
+     */
+    protected static void joinTeam(ServerPlayer player) {
+        TeamManager teamManager = TeamManager.get();
+        if (teamManager.removePlayerFromTeam(player.getUUID())) { // 加入队伍前离开当前队伍
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.leaved_current_team").withStyle(ChatFormatting.YELLOW));
+        }
+
+        int newTeamId = teamManager.teamData.generateNextTeamId();
+        if (teamManager.createNewTeamAndJoin(player, newTeamId)) { // 默认尝试创建队伍
+            return;
+        }
+
+        teamManager.addPlayerToTeamInternal(player, teamManager.findNotFullTeamId(), true); // 尝试申请加入
+    }
+
+    /**
+     * 玩家尝试创建一个指定的队伍 (已存在则改为申请)。
+     * @param player 需要加入队伍的玩家
+     * @param teamId 加入队伍的 teamId
+     */
+    protected static void joinTeamSpecific(ServerPlayer player, int teamId) {
+        TeamManager teamManager = TeamManager.get();
+
+        if (teamManager.removePlayerFromTeam(player.getUUID())) { // 加入队伍前离开当前队伍
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.leaved_current_team").withStyle(ChatFormatting.YELLOW));
+        }
+
+        if (teamManager.createNewTeamAndJoin(player, teamId)) { // 手动加入队伍
+            return;
+        }
+
+        teamManager.addPlayerToTeamInternal(player, teamId, true); // 无法创建则尝试申请加入
+    }
+
+    protected static void kickPlayer(ServerPlayer sender, ServerPlayer targetPlayer) {
+        TeamManager teamManager = TeamManager.get();
+
+        if (sender == null) {
+            return;
+        } else if (targetPlayer == null) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_not_found", "").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        GamePlayer senderGamePlayer = teamManager.teamData.getGamePlayerByUUID(sender.getUUID());
+        GamePlayer targetGamePlayer = teamManager.teamData.getGamePlayerByUUID(targetPlayer.getUUID());
+
+        if (senderGamePlayer == null) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
+            return;
+        } else if (!senderGamePlayer.isLeader()) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.not_team_leader").withStyle(ChatFormatting.RED));
+            return;
+        } else if (targetGamePlayer == null || targetGamePlayer.getGameTeamId() != senderGamePlayer.getGameTeamId()) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_not_found", targetPlayer.getName()).withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        if (teamManager.removePlayerFromTeam(targetPlayer.getUUID())) { // 手动踢人
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_kicked_from_team", targetPlayer.getName()).withStyle(ChatFormatting.YELLOW));
+            ChatUtils.sendComponentMessageToPlayer(targetPlayer, Component.translatable("battleroyale.message.kicked_by_leader", sender.getName()).withStyle(ChatFormatting.RED));
+        }
+    }
+
+    public static void invitePlayer(ServerPlayer sender, ServerPlayer targetPlayer) {
+        TeamManager teamManager = TeamManager.get();
+
+        GamePlayer senderGamePlayer = teamManager.teamData.getGamePlayerByUUID(sender.getUUID());
+        if (senderGamePlayer == null) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
+            return;
+        } else if (!senderGamePlayer.isLeader()) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.not_team_leader").withStyle(ChatFormatting.RED));
+            return;
+        } else if (senderGamePlayer.getTeam().getTeamMemberCount() >= teamManager.teamConfig.teamSize) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.team_full").withStyle(ChatFormatting.RED));
+            return;
+        } else if (teamManager.teamData.getGamePlayerByUUID(targetPlayer.getUUID()) != null) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_already_in_team", targetPlayer.getName()).withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        int teamId = senderGamePlayer.getGameTeamId();
+        long expiryTime = System.currentTimeMillis() + teamManager.teamConfig.teamMsgExpireTimeMillis;
+        String targetName = targetPlayer.getName().getString();
+        teamManager.pendingInvites.put(sender.getUUID(), new TeamManager.TeamInvite(targetPlayer.getUUID(), targetName, teamId, expiryTime));
+        ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.invite_sent", targetName).withStyle(ChatFormatting.GREEN));
+
+        String senderName = sender.getName().getString();
+        MutableComponent message = Component.translatable("battleroyale.message.invite_received", senderName, teamId);
+        String acceptCommand = TeamCommand.acceptInviteCommand(senderName);
+        String declineCommand = TeamCommand.declineInviteCommand(senderName);
+        MutableComponent acceptButton = Component.translatable("battleroyale.message.accept")
+                .withStyle(ChatFormatting.GREEN, ChatFormatting.BOLD)
+                .withStyle(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, acceptCommand))
+                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(acceptCommand)))
+                );
+        MutableComponent declineButton = Component.translatable("battleroyale.message.decline")
+                .withStyle(ChatFormatting.RED, ChatFormatting.BOLD)
+                .withStyle(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, declineCommand))
+                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(declineCommand)))
+                );
+
+        message.append(" ").append(acceptButton).append(" ").append(declineButton);
+        ChatUtils.sendClickableMessageToPlayer(targetPlayer, message);
+    }
+
+    public static void acceptInvite(ServerPlayer player, ServerPlayer senderPlayer) { // 接收者，发送者名称
+        TeamManager teamManager = TeamManager.get();
+
+        ServerLevel serverLevel = GameManager.get().getServerLevel();
+        if (serverLevel == null || player == null) {
+            return;
+        } else if (senderPlayer == null || !teamManager.isPlayerLeader(senderPlayer.getUUID())) { // 玩家未加载或不是队长
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_valid_invite").withStyle(ChatFormatting.RED));
+            return;
+        }
+        UUID senderUUID = senderPlayer.getUUID();
+        UUID playerUUID = player.getUUID();
+        TeamManager.TeamInvite invite = teamManager.pendingInvites.get(senderUUID);
+        if (invite == null || !invite.targetPlayerUUID().equals(playerUUID)) { // 已经改为向其他人发的邀请
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_valid_invite").withStyle(ChatFormatting.RED));
+            return;
+        } else if (invite.expiryTime() < System.currentTimeMillis()) { // 邀请是否过期
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.expired_invite").withStyle(ChatFormatting.RED));
+            teamManager.pendingInvites.remove(senderUUID);
+            return;
+        } else if (teamManager.teamData.getGamePlayerByUUID(playerUUID) != null) { // 检查接收者是否已在队伍中
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.already_in_team").withStyle(ChatFormatting.RED));
+            teamManager.pendingInvites.remove(senderUUID);
+            return;
+        }
+
+        GameTeam targetTeam = teamManager.teamData.getGameTeamById(invite.teamId());
+        String playerName = player.getName().getString();
+        if (targetTeam == null) { // 目标队伍不存在
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.team_does_not_exist", invite.teamId()).withStyle(ChatFormatting.RED));
+            teamManager.pendingInvites.remove(senderUUID);
+            return;
+        } else if (targetTeam.getTeamMembers().size() >= teamManager.teamConfig.teamSize) { // 目标队伍满员
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.team_full", invite.teamId()).withStyle(ChatFormatting.RED));
+            teamManager.pendingInvites.remove(senderUUID);
+            return;
+        }
+
+        teamManager.pendingInvites.remove(senderUUID);
+        ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.invite_accepted", invite.teamId()).withStyle(ChatFormatting.GREEN));
+        ChatUtils.sendComponentMessageToPlayer(senderPlayer, Component.translatable("battleroyale.message.player_accept_request", playerName).withStyle(ChatFormatting.GREEN));
+        teamManager.addPlayerToTeamInternal(player, invite.teamId(), false); // 同意邀请，强制加入
+    }
+
+    public static void declineInvite(ServerPlayer player, ServerPlayer senderPlayer) { // 接收者，发送者名称
+        TeamManager teamManager = TeamManager.get();
+
+        ServerLevel serverLevel = GameManager.get().getServerLevel();
+        if (serverLevel == null || player == null) {
+            return;
+        } else if (senderPlayer == null || !teamManager.isPlayerLeader(senderPlayer.getUUID())) { // 玩家未加载或不是队长
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_valid_invite").withStyle(ChatFormatting.RED));
+            return;
+        }
+        UUID senderUUID = senderPlayer.getUUID();
+        UUID playerUUID = player.getUUID();
+        TeamManager.TeamInvite invite = teamManager.pendingInvites.get(senderUUID);
+        if (invite == null || !invite.targetPlayerUUID().equals(playerUUID)) {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_valid_invite").withStyle(ChatFormatting.RED));
+            return;
+        } else if (invite.expiryTime() < System.currentTimeMillis()) { // 邀请是否过期
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.expired_invite").withStyle(ChatFormatting.RED));
+            teamManager.pendingInvites.remove(senderUUID);
+            return;
+        }
+
+        teamManager.pendingInvites.remove(senderUUID);
+        String playerName = player.getName().getString();
+        ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.invite_declined", invite.teamId()).withStyle(ChatFormatting.YELLOW));
+        ChatUtils.sendComponentMessageToPlayer(senderPlayer, Component.translatable("battleroyale.message.player_declined_invite", playerName).withStyle(ChatFormatting.RED));
+    }
+
+    public static void requestPlayer(ServerPlayer sender, ServerPlayer targetPlayer) { // 申请者，目标玩家
+        TeamManager teamManager = TeamManager.get();
+
+        ServerLevel serverLevel = GameManager.get().getServerLevel();
+        if (serverLevel == null || sender == null) {
+            return;
+        } else if (targetPlayer == null) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_not_found", "").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        GamePlayer senderGamePlayer = teamManager.teamData.getGamePlayerByUUID(sender.getUUID());
+        GamePlayer targetGamePlayer = teamManager.teamData.getGamePlayerByUUID(targetPlayer.getUUID());
+        if (senderGamePlayer != null) { // 申请者已在队伍里
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.already_in_team").withStyle(ChatFormatting.RED));
+            return;
+        } else if (targetGamePlayer == null) { // 对方不在队伍里
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.target_not_in_a_team", targetPlayer.getName()).withStyle(ChatFormatting.RED));
+            return;
+        } else if (targetGamePlayer.getTeam().getTeamMemberCount() >= teamManager.teamConfig.teamSize) { // 对方队伍已满员
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.team_full", targetPlayer.getName()).withStyle(ChatFormatting.RED));
+            return;
+        } else if (!targetGamePlayer.isLeader()) { // 对方不是队长
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_not_actual_leader", targetPlayer.getName()).withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        GameTeam gameTeam = targetGamePlayer.getTeam();
+        int targetTeamId = gameTeam.getGameTeamId();
+        long expiryTime = System.currentTimeMillis() + teamManager.teamConfig.teamMsgExpireTimeMillis;
+
+        teamManager.pendingRequests.put(sender.getUUID(), new TeamManager.TeamRequest(targetGamePlayer.getPlayerUUID(), targetGamePlayer.getPlayerName(), targetTeamId, expiryTime));
+        ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.request_sent", targetTeamId).withStyle(ChatFormatting.GREEN));
+
+        String senderName = sender.getName().getString();
+        MutableComponent message = Component.translatable("battleroyale.message.request_received", senderName);
+        String acceptCommand = TeamCommand.acceptRequestCommand(senderName);
+        String declineCommand = TeamCommand.declineRequestCommand(senderName);
+        MutableComponent acceptButton = Component.translatable("battleroyale.message.accept")
+                .withStyle(ChatFormatting.GREEN, ChatFormatting.BOLD)
+                .withStyle(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, acceptCommand))
+                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(acceptCommand)))
+                );
+        MutableComponent declineButton = Component.translatable("battleroyale.message.decline")
+                .withStyle(ChatFormatting.RED, ChatFormatting.BOLD)
+                .withStyle(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, declineCommand))
+                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(declineCommand)))
+                );
+        message.append(" ").append(acceptButton).append(" ").append(declineButton);
+
+        ChatUtils.sendClickableMessageToPlayer(targetPlayer, message);
+    }
+
+    public static void acceptRequest(ServerPlayer teamLeader, ServerPlayer requesterPlayer) { // 队长，申请者名称
+        TeamManager teamManager = TeamManager.get();
+
+        ServerLevel serverLevel = GameManager.get().getServerLevel();
+        if (serverLevel == null || teamLeader == null) {
+            return;
+        } else if (requesterPlayer == null) {
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.player_not_found", "").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        GamePlayer leaderGamePlayer = teamManager.teamData.getGamePlayerByUUID(teamLeader.getUUID());
+
+        if (leaderGamePlayer == null) {
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
+            return;
+        } else if (!leaderGamePlayer.isLeader()) {
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.not_team_leader").withStyle(ChatFormatting.RED));
+            return;
+        }
+        UUID requesterUUID = requesterPlayer.getUUID();
+        String requesterName = requesterPlayer.getName().getString();
+        TeamManager.TeamRequest request = teamManager.pendingRequests.get(requesterUUID);
+
+        if (request == null || request.requestedTeamId() != leaderGamePlayer.getGameTeamId() // 是否是发送给队长的
+                || !request.targetTeamLeaderUUID().equals(teamLeader.getUUID())) { // 已经改为向其他人发的邀请
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.no_valid_request").withStyle(ChatFormatting.RED));
+            return;
+        } else if (request.expireTime() < System.currentTimeMillis()) { // 检查请求是否过期
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.expired_request").withStyle(ChatFormatting.RED));
+            teamManager.pendingRequests.remove(requesterUUID);
+            return;
+        } else if (teamManager.teamData.getGamePlayerByUUID(requesterUUID) != null) { // 检查申请者是否已在队伍中
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.player_already_in_team", requesterName).withStyle(ChatFormatting.RED));
+            teamManager.pendingRequests.remove(requesterUUID);
+            return;
+        }
+        GameTeam targetTeam = leaderGamePlayer.getTeam();
+        if (targetTeam.getTeamMembers().size() >= teamManager.teamConfig.teamSize) { // 检查目标队伍是否满员
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.team_full", targetTeam.getGameTeamId()).withStyle(ChatFormatting.RED));
+            teamManager.pendingRequests.remove(requesterUUID);
+            return;
+        }
+
+        teamManager.pendingRequests.remove(requesterUUID);
+        ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.request_accepted", requesterName).withStyle(ChatFormatting.GREEN));
+        ChatUtils.sendComponentMessageToPlayer(requesterPlayer, Component.translatable("battleroyale.message.player_accept_request", teamLeader.getName().getString()).withStyle(ChatFormatting.GREEN));
+        teamManager.addPlayerToTeamInternal(requesterPlayer, targetTeam.getGameTeamId(), false); // 同意申请，强制加入
+    }
+
+    public static void declineRequest(ServerPlayer teamLeader, ServerPlayer requesterPlayer) { // 队长，申请者名称
+        TeamManager teamManager = TeamManager.get();
+
+        ServerLevel serverLevel = GameManager.get().getServerLevel();
+        if (serverLevel == null || teamLeader == null) {
+            return;
+        } else if (requesterPlayer == null) {
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.player_not_found", "").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        GamePlayer leaderGamePlayer = teamManager.teamData.getGamePlayerByUUID(teamLeader.getUUID());
+
+        if (leaderGamePlayer == null) {
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
+            return;
+        } else if (!leaderGamePlayer.isLeader()) {
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.not_team_leader").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        UUID requesterUUID = requesterPlayer.getUUID();
+        String requesterName = requesterPlayer.getName().getString();
+        TeamManager.TeamRequest request = teamManager.pendingRequests.get(requesterUUID);
+
+        if (request == null || !request.targetTeamLeaderUUID().equals(teamLeader.getUUID())
+                || request.requestedTeamId() != leaderGamePlayer.getGameTeamId()) {
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.no_valid_request").withStyle(ChatFormatting.RED));
+            return;
+        } else if (request.expireTime() < System.currentTimeMillis()) {
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.expired_request").withStyle(ChatFormatting.RED));
+            teamManager.pendingRequests.remove(requesterUUID);
+            return;
+        }
+
+        teamManager.pendingRequests.remove(requesterUUID);
+        ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.request_declined", requesterName).withStyle(ChatFormatting.YELLOW));
+        ChatUtils.sendComponentMessageToPlayer(requesterPlayer, Component.translatable("battleroyale.message.player_declined_request", teamLeader.getName().getString()).withStyle(ChatFormatting.RED));
+    }
+
+    public static void leaveTeam(ServerPlayer player) {
+        TeamManager teamManager = TeamManager.get();
+
+        UUID playerUUID = player.getUUID();
+        GamePlayer gamePlayer = teamManager.teamData.getGamePlayerByUUID(playerUUID);
+        if (gamePlayer == null) {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        teamManager.forceEliminatePlayerFromTeam(player); // 游戏进行时生效，退出即被淘汰，不在游戏运行时则自动跳过
+
+        if (teamManager.removePlayerFromTeam(playerUUID)) { // 不在游戏时生效，手动离开当前队伍
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.leaved_current_team").withStyle(ChatFormatting.GREEN));
+        }
+    }
+
+    /**
+     * 传送玩家至大厅，如果正在游戏中则淘汰
+     * @param player 需传送的玩家
+     */
+    public static void teleportToLobby(ServerPlayer player) {
+        if (player == null || !player.isAlive()) {
+            return;
+        }
+
+        TeamManager teamManager = TeamManager.get();
+
+        if (teamManager.teamData.hasStandingGamePlayer(player.getUUID())) { // 游戏进行中，且未被淘汰
+            if (GameManager.get().teleportToLobby(player)) { // 若游戏中传送成功才淘汰
+                teamManager.forceEliminatePlayerFromTeam(player); // 强制淘汰
+            } else {
+                BattleRoyale.LOGGER.error("Teleport in game player while not has lobby");
+                ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_lobby").withStyle(ChatFormatting.RED));
+            }
+        } else if (GameManager.get().teleportToLobby(player)) { // 传送，且传送成功
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.teleported_to_lobby").withStyle(ChatFormatting.GREEN));
+        } else {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_lobby").withStyle(ChatFormatting.RED));
+        }
+    }
+}

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManagement.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManagement.java
@@ -33,10 +33,10 @@ public class TeamManagement {
 
         int newTeamId = teamManager.findNotFullTeamId();
         if (newTeamId > 0) { // 有未满员队伍
-            teamManager.addPlayerToTeamInternal(player, teamManager.findNotFullTeamId(), false); // 直接强制加入
+            TeamManagement.addPlayerToTeamInternal(player, teamManager.findNotFullTeamId(), false); // 直接强制加入
         } else {
             newTeamId = teamManager.teamData.generateNextTeamId();
-            teamManager.createNewTeamAndJoin(player, newTeamId); // 无未满员队伍则创建队伍
+            TeamManagement.createNewTeamAndJoin(player, newTeamId); // 无未满员队伍则创建队伍
         }
     }
 

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManagement.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManagement.java
@@ -1,0 +1,257 @@
+package xiao.battleroyale.common.game.team;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.NotNull;
+import xiao.battleroyale.BattleRoyale;
+import xiao.battleroyale.common.game.GameManager;
+import xiao.battleroyale.event.DelayedEvent;
+import xiao.battleroyale.util.ChatUtils;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+/**
+ * 该类仅用于抽离TeamManager的功能实现，简化TeamManager
+ * 类似.h和.cpp的设计
+ */
+public class TeamManagement {
+
+    /**
+     * 玩家强制加入队伍，优先加入已有队伍，其次创建新队伍
+     * 适用于管理员指令或游戏初始化时的强制分配。
+     * @param player 需要加入队伍的玩家
+     */
+    protected static void forceJoinTeam(ServerPlayer player) {
+        TeamManager teamManager = TeamManager.get();
+
+        if (teamManager.removePlayerFromTeam(player.getUUID())) { // 加入队伍前离开当前队伍
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.leaved_current_team").withStyle(ChatFormatting.YELLOW));
+        }
+
+        int newTeamId = teamManager.findNotFullTeamId();
+        if (newTeamId > 0) { // 有未满员队伍
+            teamManager.addPlayerToTeamInternal(player, teamManager.findNotFullTeamId(), false); // 直接强制加入
+        } else {
+            newTeamId = teamManager.teamData.generateNextTeamId();
+            teamManager.createNewTeamAndJoin(player, newTeamId); // 无未满员队伍则创建队伍
+        }
+    }
+
+    /**
+     * 指定加入的队伍，不自动将申请的玩家离开队伍
+     * @param player 需要加入队伍的玩家
+     * @param targetTeamId 目标队伍的 ID
+     * @param request 如果为 true，则尝试直接加入（跳过队长确认）；如果为 false，则当队伍有在线成员时发送申请。
+     */
+    protected static void addPlayerToTeamInternal(ServerPlayer player, int targetTeamId, boolean request) {
+        TeamManager teamManager = TeamManager.get();
+        TeamData teamData = teamManager.teamData;
+
+        UUID playerId = player.getUUID();
+        GameTeam targetTeam = teamData.getGameTeamById(targetTeamId);
+        ServerLevel serverLevel = GameManager.get().getServerLevel();
+        if (targetTeam == null || serverLevel == null) { // 队伍不存在直接跳过
+            return;
+        } else if (teamData.getGamePlayerByUUID(playerId) != null) { // 不自动离开队伍
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.already_in_team").withStyle(ChatFormatting.YELLOW));
+            return;
+        } else if (targetTeam.getTeamMembers().size() >= teamManager.teamConfig.teamSize) { // 队伍满员
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.team_full", targetTeamId).withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        if (!request || targetTeam.getTeamMemberCount() == 0) { // 空队伍不用申请
+            // 新建 GamePlayer
+            int newPlayerId = teamData.generateNextPlayerId();
+            if (newPlayerId < 1) { // 达到人数上限
+                ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.reached_player_limit", teamManager.teamConfig.playerLimit).withStyle(ChatFormatting.RED));
+                return;
+            }
+            GamePlayer gamePlayer = new GamePlayer(player.getUUID(), player.getName().getString(), newPlayerId, false, targetTeam);
+            if (teamData.addPlayerToTeam(gamePlayer, targetTeam)) {
+                ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.joined_to_team", targetTeam.getGameTeamId()).withStyle(ChatFormatting.GREEN));
+                teamManager.notifyPlayerJoinTeam(gamePlayer); // 通知队伍成员有新玩家加入
+                GameManager.get().notifyTeamChange(targetTeam.getGameTeamId()); // 玩家加入队伍，通知更新队伍HUD
+                return;
+            }
+            BattleRoyale.LOGGER.debug("Failed to add player {} to team {}", player.getName().getString(), targetTeamId);
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.failed_to_join_team", targetTeam.getGameTeamId()).withStyle(ChatFormatting.RED));
+        } else { // 改为发送邀请
+            teamManager.requestPlayer(player, (ServerPlayer) serverLevel.getPlayerByUUID(targetTeam.getLeaderUUID()));
+        }
+    }
+
+    /**
+     * 清理掉离线GamePlayer，防止后续影响游戏结束的人数判定
+     */
+    protected static void removeOfflineGamePlayer(ServerLevel serverLevel) {
+        TeamData teamData = TeamManager.get().teamData;
+        List<GamePlayer> offlineGamePlayers = new ArrayList<>();
+        for (GamePlayer gamePlayer : teamData.getGamePlayersList()) {
+            if (!gamePlayer.isActiveEntity()) {
+                offlineGamePlayers.add(gamePlayer);
+                continue;
+            }
+            if (serverLevel != null) {
+                ServerPlayer player = (ServerPlayer) serverLevel.getPlayerByUUID(gamePlayer.getPlayerUUID());
+                if (player == null) {
+                    offlineGamePlayers.add(gamePlayer);
+                }
+            }
+        }
+
+        for (GamePlayer gamePlayer : offlineGamePlayers) {
+            String playerName = gamePlayer.getPlayerName();
+            if (teamData.removePlayer(gamePlayer)) {
+                BattleRoyale.LOGGER.debug("Removed offline gamePlayer {}", playerName);
+            }
+        }
+    }
+
+    /**
+     * 防止游戏开始时有意外的无队伍GamePlayer
+     */
+    protected static void removeNoTeamGamePlayer() {
+        TeamData teamData = TeamManager.get().teamData;
+        List<GamePlayer> noTeamPlayers = new ArrayList<>();
+        for (GamePlayer gamePlayer : teamData.getGamePlayersList()) {
+            if (gamePlayer.getTeam() == null) {
+                noTeamPlayers.add(gamePlayer);
+            }
+        }
+
+        for (GamePlayer noTeamPlayer : noTeamPlayers) {
+            if (teamData.removePlayer(noTeamPlayer)) {
+                GameManager.get().notifyLeavedMember(noTeamPlayer.getPlayerUUID(), noTeamPlayer.getGameTeamId()); // 防止游戏开始时无队伍的GamePlayer
+            }
+        }
+    }
+
+    /**
+     * 强制淘汰玩家，不包含发送系统消息
+     * 成功淘汰后发送大厅传送消息
+     */
+    protected static boolean forceEliminatePlayerSilence(GamePlayer gamePlayer) {
+        TeamManager teamManager = TeamManager.get();
+
+        if (teamManager.teamData.eliminatePlayer(gamePlayer)) {
+            // 强制淘汰后传送回大厅
+            ServerLevel serverLevel = GameManager.get().getServerLevel();
+            if (serverLevel != null) {
+                ServerPlayer player = (ServerPlayer) serverLevel.getPlayerByUUID(gamePlayer.getPlayerUUID());
+                if (player != null) {
+                    // TODO 生成战利品盒子
+                    Consumer<ServerPlayer> delayedTask = isWinner -> {
+                        GameManager.get().sendLobbyTeleportMessage(player, false);
+                    };
+                    new DelayedEvent<>(delayedTask, player, 2, "TeamManager::GameManager.get().sendLobbyTeleportMessage");
+                }
+            }
+            teamManager.onTeamChangedInGame();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * 强制淘汰玩家并向队友发送消息
+     */
+    protected static void forceEliminatePlayerFromTeam(ServerPlayer player) {
+        TeamManager teamManager = TeamManager.get();
+
+        GamePlayer gamePlayer = teamManager.teamData.getGamePlayerByUUID(player.getUUID());
+        if (gamePlayer == null) {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        boolean playerEliminatedBefore = gamePlayer.isEliminated();
+        boolean teamEliminatedBefore = gamePlayer.getTeam().isTeamEliminated();
+        if (teamManager.teamData.eliminatePlayer(player.getUUID())) {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.you_are_eliminated").withStyle(ChatFormatting.RED));
+            BattleRoyale.LOGGER.info("Force eliminated player {} (UUID: {})", player.getName().getString(), player.getUUID());
+        }
+
+        ServerLevel serverLevel = GameManager.get().getServerLevel();
+        if (serverLevel != null) {
+            if (!playerEliminatedBefore) {
+                GameManager.get().sendEliminateMessage(gamePlayer);
+                ChatUtils.sendComponentMessageToAllPlayers(serverLevel, Component.translatable("battleroyale.message.forced_elimination", player.getName()).withStyle(ChatFormatting.RED));
+            } else {
+                BattleRoyale.LOGGER.debug("GamePlayer {} has already been eliminated, TeamManager skipped sending chat message", gamePlayer.getPlayerName());
+            }
+        }
+        BattleRoyale.LOGGER.info("Force removed player {} (UUID: {})", player.getName().getString(), player.getUUID());
+
+        GameTeam gameTeam = gamePlayer.getTeam();
+        if (gameTeam.isTeamEliminated()) {
+            if (serverLevel != null) {
+                if (!teamEliminatedBefore) {
+                    ChatUtils.sendComponentMessageToAllPlayers(serverLevel, Component.translatable("battleroyale.message.team_eliminated", gameTeam.getGameTeamId()).withStyle(ChatFormatting.RED));
+                } else {
+                    BattleRoyale.LOGGER.debug("Team {} has already been eliminated, TeamManager skipped sending chat message", gameTeam.getGameTeamId());
+                }
+            }
+            BattleRoyale.LOGGER.info("Team {} has been eliminated for no standing player", gameTeam.getGameTeamId());
+        }
+        teamManager.onTeamChangedInGame();
+    }
+
+    /**
+     * 将玩家移出队伍
+     * @return 是否移出队伍
+     */
+    protected static boolean removePlayerFromTeam(@NotNull UUID playerId) {
+        TeamData teamData = TeamManager.get().teamData;
+
+        GamePlayer gamePlayer = teamData.getGamePlayerByUUID(playerId);
+        if (gamePlayer == null) {
+            return false;
+        }
+        int teamId = gamePlayer.getGameTeamId();
+
+        if (teamData.removePlayer(playerId)) {
+            GameManager.get().notifyLeavedMember(playerId, teamId); // 离队后通知不渲染队伍HUD
+            GameManager.get().notifyTeamChange(teamId); // 离队后通知队伍成员更新队伍HUD
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * 创建并加入队伍
+     * @param player 需要加入队伍的 ServerPlayer
+     * @param teamId 队伍id
+     * @return 是否加入队伍
+     */
+    protected static boolean createNewTeamAndJoin(ServerPlayer player, int teamId) {
+        TeamManager teamManager = TeamManager.get();
+
+        if (teamId < 1) {
+            return false;
+        }
+        int newPlayerId = teamManager.teamData.generateNextPlayerId();
+        if (newPlayerId < 1) {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.reached_player_limit").withStyle(ChatFormatting.RED));
+            return false;
+        }
+        GameTeam newTeam = new GameTeam(teamId, teamManager.teamConfig.getTeamColor(teamId));
+        if (!teamManager.teamData.addGameTeam(newTeam)) {
+            BattleRoyale.LOGGER.debug("Failed to create new team {} and let {} join", teamId, player.getName().getString());
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.failed_to_join_team", teamId).withStyle(ChatFormatting.RED));
+            return false;
+        }
+        GamePlayer gamePlayer = new GamePlayer(player.getUUID(), player.getName().getString(), newPlayerId, false, newTeam);
+        if (teamManager.teamData.addPlayerToTeam(gamePlayer, newTeam)) {
+            GameManager.get().notifyTeamChange(newTeam.getGameTeamId()); // 新建队伍并加入，通知更新队伍HUD
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.joined_to_team", teamId).withStyle(ChatFormatting.GREEN));
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
@@ -489,11 +489,11 @@ public class TeamManager extends AbstractGameManager {
             return;
         }
         if (serverLevel == null) {
-            BattleRoyale.LOGGER.error("TeamManager::buildVanillaTeam received a null ServerLevel, skipped build vanilla team");
+            BattleRoyale.LOGGER.error("TeamManager::buildVanillaTeamForAllGameTeams received a null ServerLevel, skipped build vanilla team");
             return;
         }
 
-        TeamUtils.buildVanillaTeam(serverLevel, hideName);
+        TeamUtils.buildVanillaTeamForAllGameTeams(serverLevel, hideName);
     }
     /**
      * 在传入的 ServerLevel 下为全体 GamePlayer 退出原版队伍

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
@@ -1,32 +1,22 @@
 package xiao.battleroyale.common.game.team;
 
 import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.HoverEvent;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.scores.PlayerTeam;
-import net.minecraft.world.scores.Scoreboard;
-import net.minecraft.world.scores.Team;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xiao.battleroyale.BattleRoyale;
-import xiao.battleroyale.command.sub.TeamCommand;
 import xiao.battleroyale.common.game.AbstractGameManager;
 import xiao.battleroyale.common.game.GameManager;
 import xiao.battleroyale.config.common.game.GameConfigManager;
 import xiao.battleroyale.config.common.game.gamerule.GameruleConfigManager;
 import xiao.battleroyale.config.common.game.gamerule.type.BattleroyaleEntry;
 import xiao.battleroyale.config.common.game.gamerule.type.GameEntry;
-import xiao.battleroyale.event.DelayedEvent;
 import xiao.battleroyale.util.ChatUtils;
-import xiao.battleroyale.util.ColorUtils;
 
 import java.util.*;
 import java.util.List;
-import java.util.function.Consumer;
 
 public class TeamManager extends AbstractGameManager {
 
@@ -383,8 +373,8 @@ public class TeamManager extends AbstractGameManager {
         TeamExternal.declineRequest(teamLeader, requesterPlayer);
     }
     // 离开队伍
-    public void leaveTeam(ServerPlayer player) {
-        TeamExternal.leaveTeam(player);
+    public boolean leaveTeam(@NotNull ServerPlayer player) {
+        return TeamExternal.leaveTeam(player);
     }
     /**
      * 传送玩家至大厅，如果正在游戏中则淘汰
@@ -408,15 +398,6 @@ public class TeamManager extends AbstractGameManager {
         }
 
         TeamManagement.forceJoinTeam(player);
-    }
-    /**
-     * 指定加入的队伍，不自动将申请的玩家离开队伍
-     * @param player 需要加入队伍的玩家
-     * @param targetTeamId 目标队伍的 ID
-     * @param request 如果为 true，则尝试直接加入（跳过队长确认）；如果为 false，则当队伍有在线成员时发送申请。
-     */
-    protected void addPlayerToTeamInternal(ServerPlayer player, int targetTeamId, boolean request) {
-        TeamManagement.addPlayerToTeamInternal(player, targetTeamId, request);
     }
     /**
      * 清理掉离线GamePlayer，防止后续影响游戏结束的人数判定
@@ -465,15 +446,6 @@ public class TeamManager extends AbstractGameManager {
 
         return TeamManagement.removePlayerFromTeam(playerId);
     }
-    /**
-     * 创建并加入队伍
-     * @param player 需要加入队伍的 ServerPlayer
-     * @param teamId 队伍id
-     * @return 是否加入队伍
-     */
-    protected boolean createNewTeamAndJoin(ServerPlayer player, int teamId) {
-        return TeamManagement.createNewTeamAndJoin(player, teamId);
-    }
 
     // -------TeamUtils-------
 
@@ -491,9 +463,6 @@ public class TeamManager extends AbstractGameManager {
     }
     public int getStandingTeamCount() {
         return TeamUtils.getStandingTeamCount();
-    }
-    public boolean isPlayerLeader(UUID playerUUID) {
-        return TeamUtils.isPlayerLeader(playerUUID);
     }
     /**
      * 找到第一个未满员队伍

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
@@ -18,10 +18,12 @@ import xiao.battleroyale.config.common.game.GameConfigManager;
 import xiao.battleroyale.config.common.game.gamerule.GameruleConfigManager;
 import xiao.battleroyale.config.common.game.gamerule.type.BattleroyaleEntry;
 import xiao.battleroyale.config.common.game.gamerule.type.GameEntry;
+import xiao.battleroyale.event.DelayedEvent;
 import xiao.battleroyale.util.ChatUtils;
 
 import java.util.*;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class TeamManager extends AbstractGameManager {
 
@@ -449,7 +451,10 @@ public class TeamManager extends AbstractGameManager {
                 ServerPlayer player = (ServerPlayer) serverLevel.getPlayerByUUID(gamePlayer.getPlayerUUID());
                 if (player != null) {
                     // TODO 生成战利品盒子
-                    GameManager.get().sendLobbyTeleportMessage(player, false);
+                    Consumer<ServerPlayer> delayedTask = isWinner -> {
+                        GameManager.get().sendLobbyTeleportMessage(player, false);
+                    };
+                    new DelayedEvent<>(delayedTask, player, 2, "TeamManager::GameManager.get().sendLobbyTeleportMessage");
                 }
             }
             onTeamChangedInGame();

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
@@ -5,7 +5,6 @@ import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.scores.PlayerTeam;
@@ -45,15 +44,15 @@ public class TeamManager extends AbstractGameManager {
         ;
     }
 
-    private final TeamConfig teamConfig = new TeamConfig();
+    protected final TeamConfig teamConfig = new TeamConfig();
     public int getPlayerLimit() { return teamConfig.playerLimit; }
     public boolean shouldAutoJoin() { return this.teamConfig.autoJoinGame; }
-    private final TeamData teamData = new TeamData();
+    protected final TeamData teamData = new TeamData();
 
-    private record TeamInvite(UUID targetPlayerUUID, String targetPlayerName, int teamId, long expiryTime) {}
-    private final Map<UUID, TeamInvite> pendingInvites = new HashMap<>(); // 键是发送者的 UUID
-    private record TeamRequest(UUID targetTeamLeaderUUID, String targetTeamLeaderName, int requestedTeamId, long expireTime) {}
-    private final Map<UUID, TeamRequest> pendingRequests = new HashMap<>(); // 键是申请者的 UUID
+    protected record TeamInvite(UUID targetPlayerUUID, String targetPlayerName, int teamId, long expiryTime) {}
+    protected final Map<UUID, TeamInvite> pendingInvites = new HashMap<>(); // 键是发送者的 UUID
+    protected record TeamRequest(UUID targetTeamLeaderUUID, String targetTeamLeaderName, int requestedTeamId, long expireTime) {}
+    protected final Map<UUID, TeamRequest> pendingRequests = new HashMap<>(); // 键是申请者的 UUID
 
     private boolean isStoppingGame = false;
 
@@ -174,48 +173,14 @@ public class TeamManager extends AbstractGameManager {
     }
 
     /**
-     * 清理掉离线GamePlayer，防止后续影响游戏结束的人数判定
+     * 通常在人数变更的时候可能提前结束游戏，手动提醒以降低 GameManager 检查频率
      */
-    private void removeOfflineGamePlayer() {
-        ServerLevel serverLevel = GameManager.get().getServerLevel();
-        List<GamePlayer> offlineGamePlayers = new ArrayList<>();
-        for (GamePlayer gamePlayer : teamData.getGamePlayersList()) {
-            if (!gamePlayer.isActiveEntity()) {
-                offlineGamePlayers.add(gamePlayer);
-                continue;
-            }
-            if (serverLevel != null) {
-                ServerPlayer player = (ServerPlayer) serverLevel.getPlayerByUUID(gamePlayer.getPlayerUUID());
-                if (player == null) {
-                    offlineGamePlayers.add(gamePlayer);
-                }
-            }
+    protected void onTeamChangedInGame() {
+        if (!GameManager.get().isInGame()) {
+            return;
         }
 
-        for (GamePlayer gamePlayer : offlineGamePlayers) {
-            String playerName = gamePlayer.getPlayerName();
-            if (teamData.removePlayer(gamePlayer)) {
-                BattleRoyale.LOGGER.debug("Removed offline gamePlayer {}", playerName);
-            }
-        }
-    }
-
-    /**
-     * 防止游戏开始时有意外的无队伍GamePlayer
-     */
-    private void removeNoTeamPlayer() {
-        List<GamePlayer> noTeamPlayers = new ArrayList<>();
-        for (GamePlayer gamePlayer : teamData.getGamePlayersList()) {
-            if (gamePlayer.getTeam() == null) {
-                noTeamPlayers.add(gamePlayer);
-            }
-        }
-
-        for (GamePlayer noTeamPlayer : noTeamPlayers) {
-            if (teamData.removePlayer(noTeamPlayer)) {
-                GameManager.get().notifyLeavedMember(noTeamPlayer.getPlayerUUID(), noTeamPlayer.getGameTeamId()); // 防止游戏开始时无队伍的GamePlayer
-            }
-        }
+        GameManager.get().checkIfGameShouldEnd();
     }
 
     @Override
@@ -245,800 +210,6 @@ public class TeamManager extends AbstractGameManager {
         }
     }
 
-    /**
-     * 通常在人数变更的时候可能提前结束游戏，手动提醒以降低 GameManager 检查频率
-     */
-    private void onTeamChangedInGame() {
-        if (!GameManager.get().isInGame()) {
-            return;
-        }
-
-        GameManager.get().checkIfGameShouldEnd();
-    }
-
-    public int getStandingTeamCount() {
-        return teamData.getTotalStandingTeamCount();
-    }
-
-    /**
-     * 返回非人机队伍数量
-     */
-    public int getPlayerTeamCount() {
-        int count = 0;
-        Set<Integer> playerTeamId = new HashSet<>();
-        for (GamePlayer gamePlayer : getGamePlayersList()) {
-            if (!gamePlayer.isBot()) {
-                int teamId = gamePlayer.getGameTeamId();
-                if (!playerTeamId.contains(teamId)) {
-                    playerTeamId.add(teamId);
-                    count++;
-                }
-            }
-        }
-        return count;
-    }
-
-    /**
-     * 返回未被淘汰的非人机队伍数量
-     */
-    public int getStandingPlayerTeamCount() {
-        int count = 0;
-        Set<Integer> playerTeamId = new HashSet<>();
-        for (GamePlayer gamePlayer : getStandingGamePlayersList()) {
-            if (!gamePlayer.isBot()) {
-                int teamId = gamePlayer.getGameTeamId();
-                if (!playerTeamId.contains(teamId)) {
-                    playerTeamId.add(teamId);
-                    count++;
-                }
-            }
-        }
-        return count;
-    }
-
-    public boolean isPlayerLeader(UUID playerUUID) {
-        GamePlayer gamePlayer = teamData.getGamePlayerByUUID(playerUUID);
-        if (gamePlayer == null) {
-            return false;
-        }
-        GameTeam gameTeam = gamePlayer.getTeam();
-        return gameTeam.isLeader(playerUUID);
-    }
-
-    /**
-     * 玩家强制加入队伍，优先加入已有队伍，其次创建新队伍
-     * 适用于管理员指令或游戏初始化时的强制分配。
-     * @param player 需要加入队伍的玩家
-     */
-    public void forceJoinTeam(ServerPlayer player) {
-        if (GameManager.get().isInGame()) {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        if (removePlayerFromTeam(player.getUUID())) { // 加入队伍前离开当前队伍
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.leaved_current_team").withStyle(ChatFormatting.YELLOW));
-        }
-
-        int newTeamId = findNotFullTeamId();
-        if (newTeamId > 0) { // 有未满员队伍
-            addPlayerToTeamInternal(player, findNotFullTeamId(), false); // 直接强制加入
-        } else {
-            newTeamId = teamData.generateNextTeamId();
-            createNewTeamAndJoin(player, newTeamId); // 无未满员队伍则创建队伍
-        }
-    }
-
-    /**
-     * 玩家加入游戏，优先创建队伍，无法创建队伍则发送申请
-     * @param player 需要加入队伍的玩家
-     */
-    public void joinTeam(ServerPlayer player) {
-        if (GameManager.get().isInGame()) {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        if (removePlayerFromTeam(player.getUUID())) { // 加入队伍前离开当前队伍
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.leaved_current_team").withStyle(ChatFormatting.YELLOW));
-        }
-
-        int newTeamId = teamData.generateNextTeamId();
-        if (createNewTeamAndJoin(player, newTeamId)) { // 默认尝试创建队伍
-            return;
-        }
-
-        addPlayerToTeamInternal(player, findNotFullTeamId(), true); // 尝试申请加入
-    }
-
-    /**
-     * 玩家尝试创建一个指定的队伍 (已存在则改为申请)。
-     * @param player 需要加入队伍的玩家
-     * @param teamId 加入队伍的 teamId
-     */
-    public void joinTeamSpecific(ServerPlayer player, int teamId) {
-        if (GameManager.get().isInGame()) {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        if (removePlayerFromTeam(player.getUUID())) { // 加入队伍前离开当前队伍
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.leaved_current_team").withStyle(ChatFormatting.YELLOW));
-        }
-
-        if (createNewTeamAndJoin(player, teamId)) { // 手动加入队伍
-            return;
-        }
-
-        addPlayerToTeamInternal(player, teamId, true); // 无法创建则尝试申请加入
-    }
-
-    /**
-     * 指定加入的队伍，不自动将申请的玩家离开队伍
-     * @param player 需要加入队伍的玩家
-     * @param targetTeamId 目标队伍的 ID
-     * @param request 如果为 true，则尝试直接加入（跳过队长确认）；如果为 false，则当队伍有在线成员时发送申请。
-     */
-    private void addPlayerToTeamInternal(ServerPlayer player, int targetTeamId, boolean request) {
-        UUID playerId = player.getUUID();
-        GameTeam targetTeam = teamData.getGameTeamById(targetTeamId);
-        ServerLevel serverLevel = GameManager.get().getServerLevel();
-        if (targetTeam == null || serverLevel == null) { // 队伍不存在直接跳过
-            return;
-        } else if (teamData.getGamePlayerByUUID(playerId) != null) { // 不自动离开队伍
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.already_in_team").withStyle(ChatFormatting.YELLOW));
-            return;
-        } else if (targetTeam.getTeamMembers().size() >= this.teamConfig.teamSize) { // 队伍满员
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.team_full", targetTeamId).withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        if (!request || targetTeam.getTeamMemberCount() == 0) { // 空队伍不用申请
-            // 新建 GamePlayer
-            int newPlayerId = teamData.generateNextPlayerId();
-            if (newPlayerId < 1) { // 达到人数上限
-                ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.reached_player_limit", this.teamConfig.playerLimit).withStyle(ChatFormatting.RED));
-                return;
-            }
-            GamePlayer gamePlayer = new GamePlayer(player.getUUID(), player.getName().getString(), newPlayerId, false, targetTeam);
-            if (teamData.addPlayerToTeam(gamePlayer, targetTeam)) {
-                ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.joined_to_team", targetTeam.getGameTeamId()).withStyle(ChatFormatting.GREEN));
-                notifyPlayerJoinTeam(gamePlayer); // 通知队伍成员有新玩家加入
-                GameManager.get().notifyTeamChange(targetTeam.getGameTeamId()); // 玩家加入队伍，通知更新队伍HUD
-                return;
-            }
-            BattleRoyale.LOGGER.debug("Failed to add player {} to team {}", player.getName().getString(), targetTeamId);
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.failed_to_join_team", targetTeam.getGameTeamId()).withStyle(ChatFormatting.RED));
-        } else { // 改为发送邀请
-            RequestPlayer(player, (ServerPlayer) serverLevel.getPlayerByUUID(targetTeam.getLeaderUUID()));
-        }
-    }
-
-    /**
-     * 通知队伍原玩家新成员入队
-     * @param newPlayer 新入队的成员
-     */
-    public void notifyPlayerJoinTeam(GamePlayer newPlayer) {
-        ServerLevel serverLevel = GameManager.get().getServerLevel();
-        GameTeam gameTeam = newPlayer.getTeam();
-        if (serverLevel == null) {
-            return;
-        }
-        String newPlayerName = newPlayer.getPlayerName();
-        for (GamePlayer member : gameTeam.getTeamMembers()) {
-            if (member == newPlayer) {
-                continue;
-            }
-            ServerPlayer teamPlayer = (ServerPlayer) serverLevel.getPlayerByUUID(member.getPlayerUUID());
-            if (teamPlayer != null) {
-                ChatUtils.sendComponentMessageToPlayer(teamPlayer, Component.translatable("battleroyale.message.player_joined_team", newPlayerName).withStyle(ChatFormatting.GREEN));
-            }
-        }
-    }
-
-    public void leaveTeam(ServerPlayer player) {
-        UUID playerUUID = player.getUUID();
-        GamePlayer gamePlayer = teamData.getGamePlayerByUUID(playerUUID);
-        if (gamePlayer == null) {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        forceEliminatePlayerFromTeam(player); // 游戏进行时生效，退出即被淘汰，不在游戏运行时则自动跳过
-
-        if (removePlayerFromTeam(playerUUID)) { // 不在游戏时生效，手动离开当前队伍
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.leaved_current_team").withStyle(ChatFormatting.GREEN));
-        }
-    }
-
-    /**
-     * 在游戏中强制淘汰玩家，不包含发送系统消息
-     * 成功淘汰后发送大厅传送消息
-     */
-    public boolean forceEliminatePlayerSilence(GamePlayer gamePlayer) {
-        if (!GameManager.get().isInGame()) {
-            BattleRoyale.LOGGER.debug("GameManager isn't in game, skipped forceEliminatePlayerSilence");
-            return false;
-        }
-
-        if (teamData.eliminatePlayer(gamePlayer)) {
-            // 强制淘汰后传送回大厅
-            ServerLevel serverLevel = GameManager.get().getServerLevel();
-            if (serverLevel != null) {
-                ServerPlayer player = (ServerPlayer) serverLevel.getPlayerByUUID(gamePlayer.getPlayerUUID());
-                if (player != null) {
-                    // TODO 生成战利品盒子
-                    Consumer<ServerPlayer> delayedTask = isWinner -> {
-                        GameManager.get().sendLobbyTeleportMessage(player, false);
-                    };
-                    new DelayedEvent<>(delayedTask, player, 2, "TeamManager::GameManager.get().sendLobbyTeleportMessage");
-                }
-            }
-            onTeamChangedInGame();
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * 在游戏中强制淘汰玩家并向队友发送消息
-     */
-    public void forceEliminatePlayerFromTeam(ServerPlayer player) {
-        if (!GameManager.get().isInGame()) {
-            return;
-        }
-
-        GamePlayer gamePlayer = teamData.getGamePlayerByUUID(player.getUUID());
-        if (gamePlayer == null) {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        boolean playerEliminatedBefore = gamePlayer.isEliminated();
-        boolean teamEliminatedBefore = gamePlayer.getTeam().isTeamEliminated();
-        if (teamData.eliminatePlayer(player.getUUID())) {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.you_are_eliminated").withStyle(ChatFormatting.RED));
-            BattleRoyale.LOGGER.info("Force eliminated player {} (UUID: {})", player.getName().getString(), player.getUUID());
-        }
-
-        ServerLevel serverLevel = GameManager.get().getServerLevel();
-        if (serverLevel != null) {
-            if (!playerEliminatedBefore) {
-                GameManager.get().sendEliminateMessage(gamePlayer);
-                ChatUtils.sendComponentMessageToAllPlayers(serverLevel, Component.translatable("battleroyale.message.forced_elimination", player.getName()).withStyle(ChatFormatting.RED));
-            } else {
-                BattleRoyale.LOGGER.debug("GamePlayer {} has already been eliminated, TeamManager skipped sending chat message", gamePlayer.getPlayerName());
-            }
-        }
-        BattleRoyale.LOGGER.info("Force removed player {} (UUID: {})", player.getName().getString(), player.getUUID());
-
-        GameTeam gameTeam = gamePlayer.getTeam();
-        if (gameTeam.isTeamEliminated()) {
-            if (serverLevel != null) {
-                if (!teamEliminatedBefore) {
-                    ChatUtils.sendComponentMessageToAllPlayers(serverLevel, Component.translatable("battleroyale.message.team_eliminated", gameTeam.getGameTeamId()).withStyle(ChatFormatting.RED));
-                } else {
-                    BattleRoyale.LOGGER.debug("Team {} has already been eliminated, TeamManager skipped sending chat message", gameTeam.getGameTeamId());
-                }
-            }
-            BattleRoyale.LOGGER.info("Team {} has been eliminated for no standing player", gameTeam.getGameTeamId());
-        }
-        onTeamChangedInGame();
-    }
-
-    public void kickPlayer(ServerPlayer sender, ServerPlayer targetPlayer) {
-        if (GameManager.get().isInGame()) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        if (sender == null) {
-            return;
-        } else if (targetPlayer == null) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_not_found", "").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        GamePlayer senderGamePlayer = teamData.getGamePlayerByUUID(sender.getUUID());
-        GamePlayer targetGamePlayer = teamData.getGamePlayerByUUID(targetPlayer.getUUID());
-
-        if (senderGamePlayer == null) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
-            return;
-        } else if (!senderGamePlayer.isLeader()) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.not_team_leader").withStyle(ChatFormatting.RED));
-            return;
-        } else if (targetGamePlayer == null || targetGamePlayer.getGameTeamId() != senderGamePlayer.getGameTeamId()) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_not_found", targetPlayer.getName()).withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        if (removePlayerFromTeam(targetPlayer.getUUID())) { // 手动踢人
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_kicked_from_team", targetPlayer.getName()).withStyle(ChatFormatting.YELLOW));
-            ChatUtils.sendComponentMessageToPlayer(targetPlayer, Component.translatable("battleroyale.message.kicked_by_leader", sender.getName()).withStyle(ChatFormatting.RED));
-        }
-    }
-
-    public void invitePlayer(ServerPlayer sender, ServerPlayer targetPlayer) {
-        if (GameManager.get().isInGame()) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        GamePlayer senderGamePlayer = teamData.getGamePlayerByUUID(sender.getUUID());
-        if (senderGamePlayer == null) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
-            return;
-        } else if (!senderGamePlayer.isLeader()) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.not_team_leader").withStyle(ChatFormatting.RED));
-            return;
-        } else if (senderGamePlayer.getTeam().getTeamMemberCount() >= this.teamConfig.teamSize) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.team_full").withStyle(ChatFormatting.RED));
-            return;
-        } else if (teamData.getGamePlayerByUUID(targetPlayer.getUUID()) != null) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_already_in_team", targetPlayer.getName()).withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        int teamId = senderGamePlayer.getGameTeamId();
-        long expiryTime = System.currentTimeMillis() + teamConfig.teamMsgExpireTimeMillis;
-        String targetName = targetPlayer.getName().getString();
-        pendingInvites.put(sender.getUUID(), new TeamInvite(targetPlayer.getUUID(), targetName, teamId, expiryTime));
-        ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.invite_sent", targetName).withStyle(ChatFormatting.GREEN));
-
-        String senderName = sender.getName().getString();
-        MutableComponent message = Component.translatable("battleroyale.message.invite_received", senderName, teamId);
-        String acceptCommand = TeamCommand.acceptInviteCommand(senderName);
-        String declineCommand = TeamCommand.declineInviteCommand(senderName);
-        MutableComponent acceptButton = Component.translatable("battleroyale.message.accept")
-                .withStyle(ChatFormatting.GREEN, ChatFormatting.BOLD)
-                .withStyle(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, acceptCommand))
-                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(acceptCommand)))
-                );
-        MutableComponent declineButton = Component.translatable("battleroyale.message.decline")
-                .withStyle(ChatFormatting.RED, ChatFormatting.BOLD)
-                .withStyle(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, declineCommand))
-                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(declineCommand)))
-                );
-
-        message.append(" ").append(acceptButton).append(" ").append(declineButton);
-        ChatUtils.sendClickableMessageToPlayer(targetPlayer, message);
-    }
-
-    public void acceptInvite(ServerPlayer player, ServerPlayer senderPlayer) { // 接收者，发送者名称
-        if (GameManager.get().isInGame()) {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        ServerLevel serverLevel = GameManager.get().getServerLevel();
-        if (serverLevel == null || player == null) {
-            return;
-        } else if (senderPlayer == null || !isPlayerLeader(senderPlayer.getUUID())) { // 玩家未加载或不是队长
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_valid_invite").withStyle(ChatFormatting.RED));
-            return;
-        }
-        UUID senderUUID = senderPlayer.getUUID();
-        UUID playerUUID = player.getUUID();
-        TeamInvite invite = pendingInvites.get(senderUUID);
-        if (invite == null || !invite.targetPlayerUUID().equals(playerUUID)) { // 已经改为向其他人发的邀请
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_valid_invite").withStyle(ChatFormatting.RED));
-            return;
-        } else if (invite.expiryTime() < System.currentTimeMillis()) { // 邀请是否过期
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.expired_invite").withStyle(ChatFormatting.RED));
-            pendingInvites.remove(senderUUID);
-            return;
-        } else if (teamData.getGamePlayerByUUID(playerUUID) != null) { // 检查接收者是否已在队伍中
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.already_in_team").withStyle(ChatFormatting.RED));
-            pendingInvites.remove(senderUUID);
-            return;
-        }
-
-        GameTeam targetTeam = teamData.getGameTeamById(invite.teamId());
-        String playerName = player.getName().getString();
-        if (targetTeam == null) { // 目标队伍不存在
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.team_does_not_exist", invite.teamId()).withStyle(ChatFormatting.RED));
-            pendingInvites.remove(senderUUID);
-            return;
-        } else if (targetTeam.getTeamMembers().size() >= this.teamConfig.teamSize) { // 目标队伍满员
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.team_full", invite.teamId()).withStyle(ChatFormatting.RED));
-            pendingInvites.remove(senderUUID);
-            return;
-        }
-
-        pendingInvites.remove(senderUUID);
-        ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.invite_accepted", invite.teamId()).withStyle(ChatFormatting.GREEN));
-        ChatUtils.sendComponentMessageToPlayer(senderPlayer, Component.translatable("battleroyale.message.player_accept_request", playerName).withStyle(ChatFormatting.GREEN));
-        addPlayerToTeamInternal(player, invite.teamId(), false); // 同意邀请，强制加入
-    }
-
-    public void declineInvite(ServerPlayer player, ServerPlayer senderPlayer) { // 接收者，发送者名称
-        if (GameManager.get().isInGame()) {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        ServerLevel serverLevel = GameManager.get().getServerLevel();
-        if (serverLevel == null || player == null) {
-            return;
-        } else if (senderPlayer == null || !isPlayerLeader(senderPlayer.getUUID())) { // 玩家未加载或不是队长
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_valid_invite").withStyle(ChatFormatting.RED));
-            return;
-        }
-        UUID senderUUID = senderPlayer.getUUID();
-        UUID playerUUID = player.getUUID();
-        TeamInvite invite = pendingInvites.get(senderUUID);
-        if (invite == null || !invite.targetPlayerUUID().equals(playerUUID)) {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_valid_invite").withStyle(ChatFormatting.RED));
-            return;
-        } else if (invite.expiryTime() < System.currentTimeMillis()) { // 邀请是否过期
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.expired_invite").withStyle(ChatFormatting.RED));
-            pendingInvites.remove(senderUUID);
-            return;
-        }
-
-        pendingInvites.remove(senderUUID);
-        String playerName = player.getName().getString();
-        ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.invite_declined", invite.teamId()).withStyle(ChatFormatting.YELLOW));
-        ChatUtils.sendComponentMessageToPlayer(senderPlayer, Component.translatable("battleroyale.message.player_declined_invite", playerName).withStyle(ChatFormatting.RED));
-    }
-
-    public void RequestPlayer(ServerPlayer sender, ServerPlayer targetPlayer) { // 申请者，目标玩家
-        if (GameManager.get().isInGame()) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        ServerLevel serverLevel = GameManager.get().getServerLevel();
-        if (serverLevel == null || sender == null) {
-            return;
-        } else if (targetPlayer == null) {
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_not_found", "").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        GamePlayer senderGamePlayer = teamData.getGamePlayerByUUID(sender.getUUID());
-        GamePlayer targetGamePlayer = teamData.getGamePlayerByUUID(targetPlayer.getUUID());
-        if (senderGamePlayer != null) { // 申请者已在队伍里
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.already_in_team").withStyle(ChatFormatting.RED));
-            return;
-        } else if (targetGamePlayer == null) { // 对方不在队伍里
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.target_not_in_a_team", targetPlayer.getName()).withStyle(ChatFormatting.RED));
-            return;
-        } else if (targetGamePlayer.getTeam().getTeamMemberCount() >= this.teamConfig.teamSize) { // 对方队伍已满员
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.team_full", targetPlayer.getName()).withStyle(ChatFormatting.RED));
-            return;
-        } else if (!targetGamePlayer.isLeader()) { // 对方不是队长
-            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.player_not_actual_leader", targetPlayer.getName()).withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        GameTeam gameTeam = targetGamePlayer.getTeam();
-        int targetTeamId = gameTeam.getGameTeamId();
-        long expiryTime = System.currentTimeMillis() + teamConfig.teamMsgExpireTimeMillis;
-
-        pendingRequests.put(sender.getUUID(), new TeamRequest(targetGamePlayer.getPlayerUUID(), targetGamePlayer.getPlayerName(), targetTeamId, expiryTime));
-        ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.request_sent", targetTeamId).withStyle(ChatFormatting.GREEN));
-
-        String senderName = sender.getName().getString();
-        MutableComponent message = Component.translatable("battleroyale.message.request_received", senderName);
-        String acceptCommand = TeamCommand.acceptRequestCommand(senderName);
-        String declineCommand = TeamCommand.declineRequestCommand(senderName);
-        MutableComponent acceptButton = Component.translatable("battleroyale.message.accept")
-                .withStyle(ChatFormatting.GREEN, ChatFormatting.BOLD)
-                .withStyle(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, acceptCommand))
-                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(acceptCommand)))
-                );
-        MutableComponent declineButton = Component.translatable("battleroyale.message.decline")
-                .withStyle(ChatFormatting.RED, ChatFormatting.BOLD)
-                .withStyle(style -> style.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, declineCommand))
-                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(declineCommand)))
-                );
-        message.append(" ").append(acceptButton).append(" ").append(declineButton);
-
-        ChatUtils.sendClickableMessageToPlayer(targetPlayer, message);
-    }
-
-    public void acceptRequest(ServerPlayer teamLeader, ServerPlayer requesterPlayer) { // 队长，申请者名称
-        if (GameManager.get().isInGame()) {
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        ServerLevel serverLevel = GameManager.get().getServerLevel();
-        if (serverLevel == null || teamLeader == null) {
-            return;
-        } else if (requesterPlayer == null) {
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.player_not_found", "").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        GamePlayer leaderGamePlayer = teamData.getGamePlayerByUUID(teamLeader.getUUID());
-
-        if (leaderGamePlayer == null) {
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
-            return;
-        } else if (!leaderGamePlayer.isLeader()) {
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.not_team_leader").withStyle(ChatFormatting.RED));
-            return;
-        }
-        UUID requesterUUID = requesterPlayer.getUUID();
-        String requesterName = requesterPlayer.getName().getString();
-        TeamRequest request = pendingRequests.get(requesterUUID);
-
-        if (request == null || request.requestedTeamId() != leaderGamePlayer.getGameTeamId() // 是否是发送给队长的
-                || !request.targetTeamLeaderUUID().equals(teamLeader.getUUID())) { // 已经改为向其他人发的邀请
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.no_valid_request").withStyle(ChatFormatting.RED));
-            return;
-        } else if (request.expireTime() < System.currentTimeMillis()) { // 检查请求是否过期
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.expired_request").withStyle(ChatFormatting.RED));
-            pendingRequests.remove(requesterUUID);
-            return;
-        } else if (teamData.getGamePlayerByUUID(requesterUUID) != null) { // 检查申请者是否已在队伍中
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.player_already_in_team", requesterName).withStyle(ChatFormatting.RED));
-            pendingRequests.remove(requesterUUID);
-            return;
-        }
-        GameTeam targetTeam = leaderGamePlayer.getTeam();
-        if (targetTeam.getTeamMembers().size() >= this.teamConfig.teamSize) { // 检查目标队伍是否满员
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.team_full", targetTeam.getGameTeamId()).withStyle(ChatFormatting.RED));
-            pendingRequests.remove(requesterUUID);
-            return;
-        }
-
-        pendingRequests.remove(requesterUUID);
-        ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.request_accepted", requesterName).withStyle(ChatFormatting.GREEN));
-        ChatUtils.sendComponentMessageToPlayer(requesterPlayer, Component.translatable("battleroyale.message.player_accept_request", teamLeader.getName().getString()).withStyle(ChatFormatting.GREEN));
-        addPlayerToTeamInternal(requesterPlayer, targetTeam.getGameTeamId(), false); // 同意申请，强制加入
-    }
-
-    public void declineRequest(ServerPlayer teamLeader, ServerPlayer requesterPlayer) { // 队长，申请者名称
-        if (GameManager.get().isInGame()) {
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        ServerLevel serverLevel = GameManager.get().getServerLevel();
-        if (serverLevel == null || teamLeader == null) {
-            return;
-        } else if (requesterPlayer == null) {
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.player_not_found", "").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        GamePlayer leaderGamePlayer = teamData.getGamePlayerByUUID(teamLeader.getUUID());
-
-        if (leaderGamePlayer == null) {
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
-            return;
-        } else if (!leaderGamePlayer.isLeader()) {
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.not_team_leader").withStyle(ChatFormatting.RED));
-            return;
-        }
-
-        UUID requesterUUID = requesterPlayer.getUUID();
-        String requesterName = requesterPlayer.getName().getString();
-        TeamRequest request = pendingRequests.get(requesterUUID);
-
-        if (request == null || !request.targetTeamLeaderUUID().equals(teamLeader.getUUID())
-                || request.requestedTeamId() != leaderGamePlayer.getGameTeamId()) {
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.no_valid_request").withStyle(ChatFormatting.RED));
-            return;
-        } else if (request.expireTime() < System.currentTimeMillis()) {
-            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.expired_request").withStyle(ChatFormatting.RED));
-            pendingRequests.remove(requesterUUID);
-            return;
-        }
-
-        pendingRequests.remove(requesterUUID);
-        ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.request_declined", requesterName).withStyle(ChatFormatting.YELLOW));
-        ChatUtils.sendComponentMessageToPlayer(requesterPlayer, Component.translatable("battleroyale.message.player_declined_request", teamLeader.getName().getString()).withStyle(ChatFormatting.RED));
-    }
-
-    /**
-     * 游戏未开始时将玩家移出队伍
-     * @return 是否移出队伍
-     */
-    public boolean removePlayerFromTeam(@NotNull UUID playerId) {
-        if (GameManager.get().isInGame()) {
-            return false;
-        }
-
-        GamePlayer gamePlayer = teamData.getGamePlayerByUUID(playerId);
-        if (gamePlayer == null) {
-            return false;
-        }
-        int teamId = gamePlayer.getGameTeamId();
-
-        if (teamData.removePlayer(playerId)) {
-            GameManager.get().notifyLeavedMember(playerId, teamId); // 离队后通知不渲染队伍HUD
-            GameManager.get().notifyTeamChange(teamId); // 离队后通知队伍成员更新队伍HUD
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * 创建并加入队伍
-     * @param player 需要加入队伍的 ServerPlayer
-     * @param teamId 队伍id
-     * @return 是否加入队伍
-     */
-    private boolean createNewTeamAndJoin(ServerPlayer player, int teamId) {
-        if (teamId < 1) {
-            return false;
-        }
-        int newPlayerId = teamData.generateNextPlayerId();
-        if (newPlayerId < 1) {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.reached_player_limit").withStyle(ChatFormatting.RED));
-            return false;
-        }
-        GameTeam newTeam = new GameTeam(teamId, teamConfig.getTeamColor(teamId));
-        if (!teamData.addGameTeam(newTeam)) {
-            BattleRoyale.LOGGER.debug("Failed to create new team {} and let {} join", teamId, player.getName().getString());
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.failed_to_join_team", teamId).withStyle(ChatFormatting.RED));
-            return false;
-        }
-        GamePlayer gamePlayer = new GamePlayer(player.getUUID(), player.getName().getString(), newPlayerId, false, newTeam);
-        if (teamData.addPlayerToTeam(gamePlayer, newTeam)) {
-            GameManager.get().notifyTeamChange(newTeam.getGameTeamId()); // 新建队伍并加入，通知更新队伍HUD
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.joined_to_team", teamId).withStyle(ChatFormatting.GREEN));
-            return true;
-        }
-        return false;
-    }
-
-
-    /**
-     * 找到第一个未满员队伍
-     * @return 可用的队伍，如无则 null
-     */
-    private int findNotFullTeamId() {
-        if (teamData.getTotalPlayerCount() >= this.teamConfig.playerLimit) {
-            return -1;
-        }
-
-        // 寻找已有的未满员队伍
-        List<Integer> idList = new ArrayList<>();
-        for (GameTeam team : teamData.getGameTeamsList()) {
-            if (team.getTeamMembers().size() < this.teamConfig.teamSize) {
-                idList.add(team.getGameTeamId());
-            }
-        }
-        Collections.shuffle(idList);
-        if (idList.isEmpty()) {
-            return -1;
-        }
-        return idList.get(0);
-    }
-
-    public void sendPlayerTeamId(ServerPlayer player) {
-        GamePlayer gamePlayer = getGamePlayerByUUID(player.getUUID());
-        if (gamePlayer == null) {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
-            return;
-        }
-        ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.your_team_id", gamePlayer.getGameTeamId()).withStyle(ChatFormatting.AQUA));
-    }
-
-    /**
-     * 传送玩家至大厅，如果正在游戏中则淘汰
-     * @param player 需传送的玩家
-     */
-    public void teleportToLobby(ServerPlayer player) {
-        if (player == null || !player.isAlive()) {
-            return;
-        }
-
-        if (teamData.hasStandingGamePlayer(player.getUUID())) { // 游戏进行中，且未被淘汰
-            if (GameManager.get().teleportToLobby(player)) { // 若游戏中传送成功才淘汰
-                forceEliminatePlayerFromTeam(player); // 强制淘汰
-            } else {
-                BattleRoyale.LOGGER.error("Teleport in game player while not has lobby");
-                ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_lobby").withStyle(ChatFormatting.RED));
-            }
-        } else if (GameManager.get().teleportToLobby(player)) { // 传送，且传送成功
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.teleported_to_lobby").withStyle(ChatFormatting.GREEN));
-        } else {
-            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.no_lobby").withStyle(ChatFormatting.RED));
-        }
-    }
-
-    /**
-     * 在传入的 ServerLevel 下为全体 GamePlayer 构建原版队伍
-     * @param serverLevel 用于从 GamePlayer 获取 ServerPlayer 的维度
-     * @param hideName 是否向其他队伍隐藏名称
-     */
-    public void buildVanillaTeam(@Nullable ServerLevel serverLevel, boolean hideName) {
-        GameManager gameManager = GameManager.get();
-        if (gameManager.isInGame()) {
-            BattleRoyale.LOGGER.debug("GameManager is in game, reject to build vanilla team");
-            return;
-        }
-        if (serverLevel == null) {
-            BattleRoyale.LOGGER.error("TeamManager::buildVanillaTeam received a null ServerLevel, skipped build vanilla team");
-            return;
-        }
-
-        Scoreboard scoreboard = serverLevel.getScoreboard();
-        for (GameTeam gameTeam : getGameTeamsList()) {
-            int teamId = gameTeam.getGameTeamId();
-            String vanillaTeamName = String.format("CBR Team %s", teamId);
-
-            // 移除同名Vanilla队伍
-            PlayerTeam existingTeam = scoreboard.getPlayerTeam(vanillaTeamName);
-            if (existingTeam != null) {
-                scoreboard.removePlayerTeam(existingTeam);
-                BattleRoyale.LOGGER.debug("Removed vanilla team {}", vanillaTeamName);
-            }
-
-            // 创建Vanilla队伍
-            PlayerTeam vanillaTeam = scoreboard.getPlayerTeam(vanillaTeamName);
-            if (vanillaTeam == null) {
-                vanillaTeam = scoreboard.addPlayerTeam(vanillaTeamName);
-            }
-
-            // 友伤由模组监听的事件处理免伤
-            vanillaTeam.setAllowFriendlyFire(true);
-            if (hideName) { // 对其他队伍隐藏名称
-                vanillaTeam.setNameTagVisibility(Team.Visibility.HIDE_FOR_OTHER_TEAMS);
-            } else {
-                vanillaTeam.setNameTagVisibility(Team.Visibility.ALWAYS);
-            }
-
-            // 队伍颜色取与GameTeam最近的（原版api限制）
-            vanillaTeam.setColor(ColorUtils.getClosestChatFormatting(gameTeam.getGameTeamColor()));
-            for (GamePlayer gamePlayer : gameTeam.getTeamMembers()) { // 原版队伍没有队长，直接遍历
-                ServerPlayer memberPlayer = (ServerPlayer) serverLevel.getPlayerByUUID(gamePlayer.getPlayerUUID());
-                if (memberPlayer == null) {
-                    BattleRoyale.LOGGER.warn("Failed to get GamePlayer[{}][{}]{}, skipped build vanilla team", gamePlayer.getGameTeamId(), gamePlayer.getGameSingleId(), gamePlayer.getPlayerName());
-                    continue;
-                }
-                String playerName = memberPlayer.getName().getString();
-//                // 离开队伍
-//                scoreboard.removePlayerFromTeam(playerName);
-                // 加入队伍（原版已经处理了离开队伍）
-                scoreboard.addPlayerToTeam(playerName, vanillaTeam);
-            }
-        }
-        BattleRoyale.LOGGER.debug("TeamManager finished build vanilla team");
-    }
-
-    /**
-     * 在传入的 ServerLevel 下为全体 GamePlayer 退出原版队伍
-     * @param serverLevel 用于从 GamePlayer 获取 ServerPlayer 的维度
-     */
-    public void clearVanillaTeam(@Nullable ServerLevel serverLevel) {
-        if (serverLevel == null) {
-            BattleRoyale.LOGGER.debug("TeamManager::clearVanillaTeam received a null ServerLevel, skipped clear vanilla team");
-            return;
-        }
-
-        Scoreboard scoreboard = serverLevel.getScoreboard();
-        for (GamePlayer gamePlayer : getGamePlayersList()) {
-            ServerPlayer player = (ServerPlayer) serverLevel.getPlayerByUUID(gamePlayer.getPlayerUUID());
-            if (player == null) {
-                BattleRoyale.LOGGER.warn("Failed to get GamePlayer[{}][{}]{}, skipped clear vanilla team", gamePlayer.getGameTeamId(), gamePlayer.getGameSingleId(), gamePlayer.getPlayerName());
-                continue;
-            }
-            String playerName = player.getName().getString();
-            scoreboard.removePlayerFromTeam(playerName);
-        }
-    }
-
-    public void onBotGamePlayerChanged(GamePlayer gamePlayer, UUID newPlayerUUID) {
-        if (getGamePlayerByUUID(newPlayerUUID) != null) {
-            return;
-        }
-        teamData.changeBotGamePlayer(gamePlayer, newPlayerUUID);
-    }
-
-    public List<GameTeam> getGameTeamsList() {
-        return teamData.getGameTeamsList();
-    }
-
     @Nullable
     public GameTeam getGameTeamById(int teamId) {
         if (isStoppingGame) { // TeamMessageManager通过gameTeam来build消息，特殊处理
@@ -1047,6 +218,10 @@ public class TeamManager extends AbstractGameManager {
             return null;
         }
         return teamData.getGameTeamById(teamId);
+    }
+
+    public List<GameTeam> getGameTeamsList() {
+        return teamData.getGameTeamsList();
     }
 
     public @Nullable GamePlayer getGamePlayerByUUID(UUID playerUUID) { return teamData.getGamePlayerByUUID(playerUUID); }
@@ -1075,6 +250,13 @@ public class TeamManager extends AbstractGameManager {
         return teamData.getTotalPlayerCount();
     }
 
+    public void onBotGamePlayerChanged(GamePlayer gamePlayer, UUID newPlayerUUID) {
+        if (getGamePlayerByUUID(newPlayerUUID) != null) {
+            return;
+        }
+        teamData.changeBotGamePlayer(gamePlayer, newPlayerUUID);
+    }
+
     /**
      * 尝试清除队伍信息，如果新的玩家数量限制缩小则清除，扩大限制则扩大可用id池
      */
@@ -1097,32 +279,263 @@ public class TeamManager extends AbstractGameManager {
         pendingRequests.clear();
     }
 
+    // -------TeamNofitication-------
+
+    /**
+     * 通知队伍原玩家新成员入队
+     * @param newGamePlayer 新入队的成员
+     */
+    public void notifyPlayerJoinTeam(GamePlayer newGamePlayer) {
+        TeamNotification.notifyPlayerJoinTeam(newGamePlayer, GameManager.get().getServerLevel());
+    }
+    public void sendPlayerTeamId(ServerPlayer player) {
+        TeamNotification.sendPlayerTeamId(player);
+    }
+
+    // -------TeamExternal-------
+
+    /**
+     * 玩家加入游戏，优先创建队伍，无法创建队伍则发送申请
+     * @param player 需要加入队伍的玩家
+     */
+    public void joinTeam(ServerPlayer player) {
+        if (GameManager.get().isInGame()) {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        TeamExternal.joinTeam(player);
+    }
+    /**
+     * 玩家尝试创建一个指定的队伍 (已存在则改为申请)。
+     * @param player 需要加入队伍的玩家
+     * @param teamId 加入队伍的 teamId
+     */
+    public void joinTeamSpecific(ServerPlayer player, int teamId) {
+        if (GameManager.get().isInGame()) {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        TeamExternal.joinTeamSpecific(player, teamId);
+    }
+    // 踢出队伍
+    public void kickPlayer(ServerPlayer sender, ServerPlayer targetPlayer) {
+        if (GameManager.get().isInGame()) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        TeamExternal.kickPlayer(sender, targetPlayer);
+    }
+    // 邀请玩家
+    public void invitePlayer(ServerPlayer sender, ServerPlayer targetPlayer) {
+        if (GameManager.get().isInGame()) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        TeamExternal.invitePlayer(sender, targetPlayer);
+    }
+    // 接收邀请
+    public void acceptInvite(ServerPlayer player, ServerPlayer senderPlayer) { // 接收者，发送者名称
+        if (GameManager.get().isInGame()) {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        TeamExternal.acceptInvite(player, senderPlayer);
+    }
+    // 拒绝邀请
+    public void declineInvite(ServerPlayer player, ServerPlayer senderPlayer) { // 接收者，发送者名称
+        if (GameManager.get().isInGame()) {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        TeamExternal.declineInvite(player, senderPlayer);
+    }
+    // 申请入队
+    public void requestPlayer(ServerPlayer sender, ServerPlayer targetPlayer) { // 申请者，目标玩家
+        if (GameManager.get().isInGame()) {
+            ChatUtils.sendComponentMessageToPlayer(sender, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        TeamExternal.requestPlayer(sender, targetPlayer);
+    }
+    // 接收申请
+    public void acceptRequest(ServerPlayer teamLeader, ServerPlayer requesterPlayer) { // 队长，申请者名称
+        if (GameManager.get().isInGame()) {
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        TeamExternal.acceptRequest(teamLeader, requesterPlayer);
+    }
+    // 拒绝申请
+    public void declineRequest(ServerPlayer teamLeader, ServerPlayer requesterPlayer) { // 队长，申请者名称
+        if (GameManager.get().isInGame()) {
+            ChatUtils.sendComponentMessageToPlayer(teamLeader, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        TeamExternal.declineRequest(teamLeader, requesterPlayer);
+    }
+    // 离开队伍
+    public void leaveTeam(ServerPlayer player) {
+        TeamExternal.leaveTeam(player);
+    }
+    /**
+     * 传送玩家至大厅，如果正在游戏中则淘汰
+     * @param player 需传送的玩家
+     */
+    public void teleportToLobby(ServerPlayer player) {
+        TeamExternal.teleportToLobby(player);
+    }
+
+    // -------TeamManagement-------
+
+    /**
+     * 玩家强制加入队伍，优先加入已有队伍，其次创建新队伍
+     * 适用于管理员指令或游戏初始化时的强制分配。
+     * @param player 需要加入队伍的玩家
+     */
+    public void forceJoinTeam(ServerPlayer player) {
+        if (GameManager.get().isInGame()) {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.game_in_progress").withStyle(ChatFormatting.RED));
+            return;
+        }
+
+        TeamManagement.forceJoinTeam(player);
+    }
+    /**
+     * 指定加入的队伍，不自动将申请的玩家离开队伍
+     * @param player 需要加入队伍的玩家
+     * @param targetTeamId 目标队伍的 ID
+     * @param request 如果为 true，则尝试直接加入（跳过队长确认）；如果为 false，则当队伍有在线成员时发送申请。
+     */
+    protected void addPlayerToTeamInternal(ServerPlayer player, int targetTeamId, boolean request) {
+        TeamManagement.addPlayerToTeamInternal(player, targetTeamId, request);
+    }
+    /**
+     * 清理掉离线GamePlayer，防止后续影响游戏结束的人数判定
+     */
+    private void removeOfflineGamePlayer() {
+        TeamManagement.removeOfflineGamePlayer(GameManager.get().getServerLevel());
+    }
+    /**
+     * 防止游戏开始时有意外的无队伍GamePlayer
+     */
+    private void removeNoTeamPlayer() {
+        TeamManagement.removeNoTeamGamePlayer();
+    }
+    /**
+     * 在游戏中强制淘汰玩家，不包含发送系统消息
+     * 成功淘汰后发送大厅传送消息
+     */
+    public boolean forceEliminatePlayerSilence(GamePlayer gamePlayer) {
+        if (!GameManager.get().isInGame()) {
+            BattleRoyale.LOGGER.debug("GameManager isn't in game, skipped forceEliminatePlayerSilence");
+            return false;
+        }
+
+        return TeamManagement.forceEliminatePlayerSilence(gamePlayer);
+    }
+    /**
+     * 在游戏中强制淘汰玩家并向队友发送消息
+     */
+    public void forceEliminatePlayerFromTeam(ServerPlayer player) {
+        if (!GameManager.get().isInGame()) {
+            BattleRoyale.LOGGER.debug("GameManager isn't in game, skipped forceEliminatePlayerFromTeam");
+            return;
+        }
+
+        TeamManagement.forceEliminatePlayerFromTeam(player);
+    }
+    /**
+     * 游戏未开始时将玩家移出队伍
+     * @return 是否移出队伍
+     */
+    public boolean removePlayerFromTeam(@NotNull UUID playerId) {
+        if (GameManager.get().isInGame()) {
+            BattleRoyale.LOGGER.debug("GameManager is in game, skipped removePlayerFromTeam");
+            return false;
+        }
+
+        return TeamManagement.removePlayerFromTeam(playerId);
+    }
+    /**
+     * 创建并加入队伍
+     * @param player 需要加入队伍的 ServerPlayer
+     * @param teamId 队伍id
+     * @return 是否加入队伍
+     */
+    protected boolean createNewTeamAndJoin(ServerPlayer player, int teamId) {
+        return TeamManagement.createNewTeamAndJoin(player, teamId);
+    }
+
+    // -------TeamUtils-------
+
+    /**
+     * 返回非人机队伍数量
+     */
+    public int getNonBotTeamCount() {
+        return TeamUtils.getNonBotTeamCount();
+    }
+    /**
+     * 返回未被淘汰的非人机队伍数量
+     */
+    public int getStandingPlayerTeamCount() {
+        return TeamUtils.getStandingPlayerTeamCount();
+    }
+    public int getStandingTeamCount() {
+        return TeamUtils.getStandingTeamCount();
+    }
+    public boolean isPlayerLeader(UUID playerUUID) {
+        return TeamUtils.isPlayerLeader(playerUUID);
+    }
+    /**
+     * 找到第一个未满员队伍
+     * @return 可用的队伍，如无则返回 -1
+     */
+    protected int findNotFullTeamId() {
+        return TeamUtils.findNotFullTeamId();
+    }
     /**
      * 判断是否有足够队伍开始游戏
      */
-    private boolean hasEnoughPlayerTeamToStart() {
-        return hasEnoughPlayerToStart() && hasEnoughTeamToStart();
+    protected boolean hasEnoughPlayerTeamToStart() {
+        return TeamUtils.hasEnoughPlayerTeamToStart();
     }
-    private boolean hasEnoughPlayerToStart() {
-        int totalPlayerAndBots = getTotalMembers();
-        int minTeam = GameManager.get().getRequiredGameTeam();
-        return totalPlayerAndBots >= minTeam // 真人玩家满足最小单人队限制
-                || this.teamConfig.aiEnemy; // TODO 人机填充
-    }
-    private boolean hasEnoughTeamToStart() {
-        if (!GameManager.get().getGameEntry().allowRemainingBot) { // 不允许剩余人机打架 -> 开局不能直接只剩人机队
-            List<GameTeam> gameTeams = getGameTeamsList();
-            for (GameTeam gameTeam : gameTeams) {
-                if (!gameTeam.onlyRemainBot()) {
-                    return true;
-                }
-            }
-            return false;
-        } else { // 允许人机打架
-            int totalPlayerTeam = getPlayerTeamCount();
-            int minTeam = GameManager.get().getRequiredGameTeam();
-            return totalPlayerTeam >= minTeam // 满足最小队伍限制
-                    || this.teamConfig.aiEnemy; // TODO 人机填充
+    /**
+     * 在传入的 ServerLevel 下为全体 GamePlayer 构建原版队伍
+     * @param serverLevel 用于从 GamePlayer 获取 ServerPlayer 的维度
+     * @param hideName 是否向其他队伍隐藏名称
+     */
+    public void buildVanillaTeam(@Nullable ServerLevel serverLevel, boolean hideName) {
+        GameManager gameManager = GameManager.get();
+        if (gameManager.isInGame()) {
+            BattleRoyale.LOGGER.debug("GameManager is in game, reject to build vanilla team");
+            return;
         }
+        if (serverLevel == null) {
+            BattleRoyale.LOGGER.error("TeamManager::buildVanillaTeam received a null ServerLevel, skipped build vanilla team");
+            return;
+        }
+
+        TeamUtils.buildVanillaTeam(serverLevel, hideName);
+    }
+    /**
+     * 在传入的 ServerLevel 下为全体 GamePlayer 退出原版队伍
+     * @param serverLevel 用于从 GamePlayer 获取 ServerPlayer 的维度
+     */
+    public void clearVanillaTeam(@Nullable ServerLevel serverLevel) {
+        if (serverLevel == null) {
+            BattleRoyale.LOGGER.debug("TeamManager::clearVanillaTeam received a null ServerLevel, skipped clear vanilla team");
+            return;
+        }
+
+        TeamUtils.clearVanillaTeam(serverLevel);
     }
 }

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
@@ -5,6 +5,7 @@ import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import org.jetbrains.annotations.NotNull;
@@ -217,21 +218,11 @@ public class TeamManager extends AbstractGameManager {
             for (GamePlayer gamePlayer : getGamePlayersList()) { // 触发频率低，问题不大。。。
                 gameManager.notifyLeavedMember(gamePlayer.getPlayerUUID(), gamePlayer.getGameTeamId());
             }
-            if (serverLevel != null) {
-                BattleRoyale.LOGGER.debug("TeamManager start delayed clear()");
-                // 延迟2tick保证MessageManager获取到GamePlayer并保证在发送的tick之后再执行this.clear()
-                serverLevel.getServer().execute(() -> {
-                    serverLevel.getServer().execute(() -> {
-                        this.clear(); // 延迟2tick的clear
-                        isStoppingGame = false;
-                        BattleRoyale.LOGGER.debug("TeamManager finished delayed clear()");
-                    });
-                });
-            } else {
-                BattleRoyale.LOGGER.debug("TeamManager start instant clear()");
-                this.clear(); // stopGame立即执行的clear
-                isStoppingGame = false;
-            }
+            isStoppingGame = false;
+
+            // TeamMessageManager的消息中有保留旧队伍信息，不需要延迟清理
+            this.clear();
+            BattleRoyale.LOGGER.debug("TeamManager finished clear()");
         }
     }
 

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamNotification.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamNotification.java
@@ -1,0 +1,45 @@
+package xiao.battleroyale.common.game.team;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import xiao.battleroyale.util.ChatUtils;
+
+/**
+ * 该类仅用于抽离TeamManager的功能实现，简化TeamManager
+ * 类似.h和.cpp的设计
+ */
+public class TeamNotification {
+
+    /**
+     * 通知队伍原玩家新成员入队
+     * @param newGamePlayer 新入队的成员
+     */
+    public static void notifyPlayerJoinTeam(GamePlayer newGamePlayer, ServerLevel serverLevel) {
+        GameTeam gameTeam = newGamePlayer.getTeam();
+        if (serverLevel == null) {
+            return;
+        }
+        String newPlayerName = newGamePlayer.getPlayerName();
+        for (GamePlayer member : gameTeam.getTeamMembers()) {
+            if (member == newGamePlayer) {
+                continue;
+            }
+            ServerPlayer teamPlayer = (ServerPlayer) serverLevel.getPlayerByUUID(member.getPlayerUUID());
+            if (teamPlayer != null) {
+                ChatUtils.sendComponentMessageToPlayer(teamPlayer, Component.translatable("battleroyale.message.player_joined_team", newPlayerName).withStyle(ChatFormatting.GREEN));
+            }
+        }
+    }
+
+    public static void sendPlayerTeamId(ServerPlayer player) {
+        TeamManager teamManager = TeamManager.get();
+        GamePlayer gamePlayer = teamManager.getGamePlayerByUUID(player.getUUID());
+        if (gamePlayer == null) {
+            ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.not_in_a_team").withStyle(ChatFormatting.RED));
+            return;
+        }
+        ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.your_team_id", gamePlayer.getGameTeamId()).withStyle(ChatFormatting.AQUA));
+    }
+}

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamUtils.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamUtils.java
@@ -1,0 +1,197 @@
+package xiao.battleroyale.common.game.team;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.scores.PlayerTeam;
+import net.minecraft.world.scores.Scoreboard;
+import net.minecraft.world.scores.Team;
+import org.jetbrains.annotations.NotNull;
+import xiao.battleroyale.BattleRoyale;
+import xiao.battleroyale.common.game.GameManager;
+import xiao.battleroyale.util.ColorUtils;
+
+import java.util.*;
+
+/**
+ * 该类仅用于抽离TeamManager的功能实现，简化TeamManager
+ * 类似.h和.cpp的设计
+ */
+public class TeamUtils {
+
+    /**
+     * 返回非人机队伍数量
+     */
+    public static int getNonBotTeamCount() {
+        TeamManager teamManager = TeamManager.get();
+        int count = 0;
+        Set<Integer> playerTeamId = new HashSet<>();
+        for (GamePlayer gamePlayer : teamManager.getGamePlayersList()) {
+            if (!gamePlayer.isBot()) {
+                int teamId = gamePlayer.getGameTeamId();
+                if (!playerTeamId.contains(teamId)) {
+                    playerTeamId.add(teamId);
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    /**
+     * 返回未被淘汰的非人机队伍数量
+     */
+    public static int getStandingPlayerTeamCount() {
+        TeamManager teamManager = TeamManager.get();
+        int count = 0;
+        Set<Integer> playerTeamId = new HashSet<>();
+        for (GamePlayer gamePlayer : teamManager.getStandingGamePlayersList()) {
+            if (!gamePlayer.isBot()) {
+                int teamId = gamePlayer.getGameTeamId();
+                if (!playerTeamId.contains(teamId)) {
+                    playerTeamId.add(teamId);
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    public static int getStandingTeamCount() {
+        return TeamManager.get().teamData.getTotalStandingTeamCount();
+    }
+
+    public static boolean isPlayerLeader(UUID playerUUID) {
+        TeamManager teamManager = TeamManager.get();
+        GamePlayer gamePlayer = teamManager.teamData.getGamePlayerByUUID(playerUUID);
+        if (gamePlayer == null) {
+            return false;
+        }
+        GameTeam gameTeam = gamePlayer.getTeam();
+        return gameTeam.isLeader(playerUUID);
+    }
+
+    /**
+     * 找到第一个未满员队伍
+     * @return 可用的队伍，如无则返回 -1
+     */
+    public static int findNotFullTeamId() {
+        TeamManager teamManager = TeamManager.get();
+        if (teamManager.teamData.getTotalPlayerCount() >= teamManager.teamConfig.playerLimit) {
+            return -1;
+        }
+
+        // 寻找已有的未满员队伍
+        List<Integer> idList = new ArrayList<>();
+        for (GameTeam team : teamManager.teamData.getGameTeamsList()) {
+            if (team.getTeamMembers().size() < teamManager.teamConfig.teamSize) {
+                idList.add(team.getGameTeamId());
+            }
+        }
+        Collections.shuffle(idList);
+        if (idList.isEmpty()) {
+            return -1;
+        }
+        return idList.get(0);
+    }
+
+    /**
+     * 判断是否有足够队伍开始游戏
+     */
+    public static boolean hasEnoughPlayerTeamToStart() {
+        return hasEnoughPlayerToStart() && hasEnoughTeamToStart();
+    }
+    public static boolean hasEnoughPlayerToStart() {
+        TeamManager teamManager = TeamManager.get();
+        int totalPlayerAndBots = teamManager.getTotalMembers();
+        int minTeam = GameManager.get().getRequiredGameTeam();
+        return totalPlayerAndBots >= minTeam // 真人玩家满足最小单人队限制
+                || teamManager.teamConfig.aiEnemy; // TODO 人机填充
+    }
+    public static boolean hasEnoughTeamToStart() {
+        TeamManager teamManager = TeamManager.get();
+        if (!GameManager.get().getGameEntry().allowRemainingBot) { // 不允许剩余人机打架 -> 开局不能直接只剩人机队
+            List<GameTeam> gameTeams = teamManager.getGameTeamsList();
+            for (GameTeam gameTeam : gameTeams) {
+                if (!gameTeam.onlyRemainBot()) {
+                    return true;
+                }
+            }
+            return false;
+        } else { // 允许人机打架
+            int totalPlayerTeam = getNonBotTeamCount();
+            int minTeam = GameManager.get().getRequiredGameTeam();
+            return totalPlayerTeam >= minTeam // 满足最小队伍限制
+                    || teamManager.teamConfig.aiEnemy; // TODO 人机填充
+        }
+    }
+
+    /**
+     * 在传入的 ServerLevel 下为全体 GamePlayer 构建原版队伍
+     * @param serverLevel 用于从 GamePlayer 获取 ServerPlayer 的维度
+     * @param hideName 是否向其他队伍隐藏名称
+     */
+    public static void buildVanillaTeam(@NotNull ServerLevel serverLevel, boolean hideName) {
+        TeamManager teamManager = TeamManager.get();
+
+        Scoreboard scoreboard = serverLevel.getScoreboard();
+        for (GameTeam gameTeam : teamManager.getGameTeamsList()) {
+            int teamId = gameTeam.getGameTeamId();
+            String vanillaTeamName = String.format("CBR Team %s", teamId);
+
+            // 移除同名Vanilla队伍
+            PlayerTeam existingTeam = scoreboard.getPlayerTeam(vanillaTeamName);
+            if (existingTeam != null) {
+                scoreboard.removePlayerTeam(existingTeam);
+                BattleRoyale.LOGGER.debug("Removed vanilla team {}", vanillaTeamName);
+            }
+
+            // 创建Vanilla队伍
+            PlayerTeam vanillaTeam = scoreboard.getPlayerTeam(vanillaTeamName);
+            if (vanillaTeam == null) {
+                vanillaTeam = scoreboard.addPlayerTeam(vanillaTeamName);
+            }
+
+            // 友伤由模组监听的事件处理免伤
+            vanillaTeam.setAllowFriendlyFire(true);
+            if (hideName) { // 对其他队伍隐藏名称
+                vanillaTeam.setNameTagVisibility(Team.Visibility.HIDE_FOR_OTHER_TEAMS);
+            } else {
+                vanillaTeam.setNameTagVisibility(Team.Visibility.ALWAYS);
+            }
+
+            // 队伍颜色取与GameTeam最近的（原版api限制）
+            vanillaTeam.setColor(ColorUtils.getClosestChatFormatting(gameTeam.getGameTeamColor()));
+            for (GamePlayer gamePlayer : gameTeam.getTeamMembers()) { // 原版队伍没有队长，直接遍历
+                ServerPlayer memberPlayer = (ServerPlayer) serverLevel.getPlayerByUUID(gamePlayer.getPlayerUUID());
+                if (memberPlayer == null) {
+                    BattleRoyale.LOGGER.warn("Failed to get GamePlayer[{}][{}]{}, skipped build vanilla team", gamePlayer.getGameTeamId(), gamePlayer.getGameSingleId(), gamePlayer.getPlayerName());
+                    continue;
+                }
+                String playerName = memberPlayer.getName().getString();
+//                // 离开队伍
+//                scoreboard.removePlayerFromTeam(playerName);
+                // 加入队伍（原版已经处理了离开队伍）
+                scoreboard.addPlayerToTeam(playerName, vanillaTeam);
+            }
+        }
+        BattleRoyale.LOGGER.debug("TeamManager finished build vanilla team");
+    }
+
+    /**
+     * 在传入的 ServerLevel 下为全体 GamePlayer 退出原版队伍
+     * @param serverLevel 用于从 GamePlayer 获取 ServerPlayer 的维度
+     */
+    public static void clearVanillaTeam(@NotNull ServerLevel serverLevel) {
+        TeamManager teamManager = TeamManager.get();
+        Scoreboard scoreboard = serverLevel.getScoreboard();
+        for (GamePlayer gamePlayer : teamManager.getGamePlayersList()) {
+            ServerPlayer player = (ServerPlayer) serverLevel.getPlayerByUUID(gamePlayer.getPlayerUUID());
+            if (player == null) {
+                BattleRoyale.LOGGER.warn("Failed to get GamePlayer[{}][{}]{}, skipped clear vanilla team", gamePlayer.getGameTeamId(), gamePlayer.getGameSingleId(), gamePlayer.getPlayerName());
+                continue;
+            }
+            String playerName = player.getName().getString();
+            scoreboard.removePlayerFromTeam(playerName);
+        }
+    }
+}

--- a/src/main/java/xiao/battleroyale/common/message/MessageManager.java
+++ b/src/main/java/xiao/battleroyale/common/message/MessageManager.java
@@ -4,6 +4,7 @@ import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.Nullable;
 import xiao.battleroyale.api.message.IMessageManager;
 import xiao.battleroyale.common.message.game.GameMessageManager;
+import xiao.battleroyale.common.message.game.SpectateMessageManager;
 import xiao.battleroyale.common.message.team.TeamMessageManager;
 import xiao.battleroyale.common.message.zone.ZoneMessageManager;
 import xiao.battleroyale.event.MessageEventHandler;
@@ -76,6 +77,15 @@ public class MessageManager {
         messageManagers.add(manager);
         MessageEventHandler.register();
     }
+    public void registerSpectateMessage() {
+        SpectateMessageManager manager = SpectateMessageManager.get();
+        if (messageManagers.contains(manager)) {
+            return;
+        }
+        manager.register(currentTime);
+        messageManagers.add(manager);
+        MessageEventHandler.register();
+    }
 
     public void addZoneNbtMessage(int zoneId, @Nullable CompoundTag nbtMessage) {
         registerZoneMessage();
@@ -118,5 +128,10 @@ public class MessageManager {
     }
     public void notifyGameChange(int channel) {
         GameMessageManager.get().notifyNbtChange(channel);
+    }
+
+    public void notifySpectateChange(int singleId) {
+        registerSpectateMessage();
+        SpectateMessageManager.get().notifyNbtChange(singleId);
     }
 }

--- a/src/main/java/xiao/battleroyale/common/message/game/GameMessage.java
+++ b/src/main/java/xiao/battleroyale/common/message/game/GameMessage.java
@@ -3,19 +3,31 @@ package xiao.battleroyale.common.message.game;
 import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.NotNull;
 import xiao.battleroyale.api.message.game.GameTag;
+import xiao.battleroyale.common.game.GameManager;
 import xiao.battleroyale.common.message.AbstractCommonMessage;
+
+import java.util.UUID;
 
 public class GameMessage extends AbstractCommonMessage {
 
-    int standingPlayerCount = 0;
+    private int standingPlayerCount;
+    private UUID gameId;
 
     public GameMessage(@NotNull CompoundTag nbt, int updateTime) {
         super(nbt, updateTime);
+        this.standingPlayerCount = 0;
+        this.gameId = GameManager.get().getGameId();
+    }
+
+    public void updateMessage(int standingPlayerCount, UUID gameId) {
+        this.standingPlayerCount = standingPlayerCount;
+        this.gameId = gameId;
     }
 
     public CompoundTag toNBT() {
         CompoundTag nbt = new CompoundTag();
         nbt.putInt(GameTag.ALIVE, standingPlayerCount);
+        nbt.putUUID(GameTag.GAMEID, gameId);
         return nbt;
     }
 }

--- a/src/main/java/xiao/battleroyale/common/message/game/GameMessageManager.java
+++ b/src/main/java/xiao/battleroyale/common/message/game/GameMessageManager.java
@@ -28,6 +28,8 @@ public class GameMessageManager extends AbstractMessageManager<GameMessage> impl
 
     public static final int ALIVE_CHANNEL = -1;
     public static final String ALIVE_KEY = Integer.toString(ALIVE_CHANNEL);
+    public static final int GAMEID_CHANNEL = -2;
+    public static final String GAMEID_KEY = Integer.toString(GAMEID_CHANNEL);
 
     @Override
     protected void checkExpiredMessage() {
@@ -39,17 +41,18 @@ public class GameMessageManager extends AbstractMessageManager<GameMessage> impl
     }
 
     protected void updateAliveTotal() {
-        boolean inGame = GameManager.get().isInGame();
+        GameManager gameManager = GameManager.get();
+        boolean inGame = gameManager.isInGame();
         if (inGame) {
-            int aliveTotal = GameManager.get().getStandingGamePlayers().size();
+            int aliveTotal = gameManager.getStandingGamePlayers().size();
             GameMessage message = getOrCreateMessage(ALIVE_CHANNEL);
-            message.standingPlayerCount = aliveTotal;
+            message.updateMessage(aliveTotal, gameManager.getGameId());
             message.nbt = message.toNBT();
             message.updateTime = currentTime;
         } else {
             if (messages.containsKey(ALIVE_CHANNEL)) {
                 GameMessage message = getOrCreateMessage(ALIVE_CHANNEL);
-                message.standingPlayerCount = 0;
+                message.updateMessage(0, gameManager.getGameId());
                 message.nbt = new CompoundTag();
                 message.updateTime = currentTime;
             } else {

--- a/src/main/java/xiao/battleroyale/common/message/game/SpectateMessage.java
+++ b/src/main/java/xiao/battleroyale/common/message/game/SpectateMessage.java
@@ -1,0 +1,50 @@
+package xiao.battleroyale.common.message.game;
+
+import net.minecraft.nbt.CompoundTag;
+import org.jetbrains.annotations.NotNull;
+import xiao.battleroyale.BattleRoyale;
+import xiao.battleroyale.common.game.team.GamePlayer;
+import xiao.battleroyale.common.message.AbstractCommonMessage;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+
+import static xiao.battleroyale.common.message.game.SpectateMessageManager.SPECTATE_KEY;
+
+public class SpectateMessage extends AbstractCommonMessage {
+
+    public int sendCooldown = 0;
+    private final Queue<GamePlayer> spectateGamePlayers = new ArrayDeque<>();
+
+    public SpectateMessage(@NotNull CompoundTag nbt, int updateTime, List<GamePlayer> gamePlayers) {
+        super(nbt, updateTime);
+        this.spectateGamePlayers.addAll(gamePlayers);
+    }
+
+    @NotNull
+    public CompoundTag toNBT(int playerTotal) {
+        CompoundTag nbt = new CompoundTag();
+        if (spectateGamePlayers.isEmpty()) {
+            return nbt;
+        }
+
+        CompoundTag spectateTag = new CompoundTag();
+        playerTotal = Math.min(playerTotal, spectateGamePlayers.size());
+        for (int i = 0; i < playerTotal; i++) {
+            GamePlayer gamePlayer = spectateGamePlayers.poll();
+            if (gamePlayer != null) { // 防御性编程，尽管不会触发
+                spectateTag.putString(gamePlayer.getPlayerUUID().toString(), gamePlayer.getGameTeamColor());
+            } else {
+                BattleRoyale.LOGGER.warn("SpectateMessage get null GamePlayer from this.spectateGamePlayers, this is unexpected");
+            }
+        }
+        nbt.put(SPECTATE_KEY, spectateTag);
+
+        return nbt;
+    }
+
+    public boolean isFinished() {
+        return spectateGamePlayers.isEmpty();
+    }
+}

--- a/src/main/java/xiao/battleroyale/common/message/game/SpectateMessageManager.java
+++ b/src/main/java/xiao/battleroyale/common/message/game/SpectateMessageManager.java
@@ -1,0 +1,107 @@
+package xiao.battleroyale.common.message.game;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.NotNull;
+import xiao.battleroyale.common.game.GameManager;
+import xiao.battleroyale.common.game.team.GamePlayer;
+import xiao.battleroyale.common.message.AbstractMessageManager;
+import xiao.battleroyale.network.message.ClientMessageSpectateInfo;
+import xiao.battleroyale.util.SendUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public class SpectateMessageManager extends AbstractMessageManager<SpectateMessage> {
+
+    private static class SpectateMessageManagerHolder {
+        private static final SpectateMessageManager INSTANCE = new SpectateMessageManager();
+    }
+
+    public static SpectateMessageManager get() {
+        return SpectateMessageManagerHolder.INSTANCE;
+    }
+
+    public static final int SPECTATE_CHANNEL = -1;
+    public static final String SPECTATE_KEY = Integer.toString(SPECTATE_CHANNEL);
+
+    private static int sendPlayerPerMessage = 20; // 防止极端情况大量发送
+    public static void setSendPlayerPerMessage(int playerTotal) { sendPlayerPerMessage = playerTotal; }
+    private static int sendInterval = 1;
+    public static void setSendInterval(int interval) { sendInterval = interval; }
+
+    @Override
+    protected void sendMessageToPlayers(List<ServerPlayer> players, CompoundTag nbtMessage, @NotNull ServerLevel serverLevel) {
+        ClientMessageSpectateInfo message = new ClientMessageSpectateInfo(nbtMessage);
+        for (ServerPlayer player : players) {
+            SendUtils.sendMessageToPlayer(player, message);
+        }
+    }
+
+    @Override
+    protected void sendMessageToGamePlayers(List<GamePlayer> gamePlayers, CompoundTag nbtMessage, @NotNull ServerLevel serverLevel) {
+        ClientMessageSpectateInfo message = new ClientMessageSpectateInfo(nbtMessage);
+        SendUtils.sendMessageToGamePlayers(gamePlayers, message, serverLevel);
+    }
+
+    @Override
+    protected void checkExpiredMessage() {
+    }
+
+    @Override
+    public void notifyNbtChange(int nbtId) {
+        changedId.add(nbtId);
+        if (!messages.containsKey(nbtId)) { // 初次创建时才传入完整GamePlayers
+            messages.put(nbtId, new SpectateMessage(new CompoundTag(), currentTime, GameManager.get().getGamePlayers()));
+        }
+    }
+
+    @Override
+    protected CompoundTag buildCommonChangedMessage() {
+        return new CompoundTag();
+    }
+
+    @Override
+    protected void sendMessages() {
+        ServerLevel serverLevel = GameManager.get().getServerLevel();
+        List<GamePlayer> sendGamePlayer = new ArrayList<>(); // 只装一个
+        List<Integer> unfinishedId = new ArrayList<>();
+
+        for (int id : changedId) {
+            SpectateMessage message = getOrCreateMessage(id);
+            message.updateTime = currentTime;
+            // 发送冷却
+            if (--message.sendCooldown > 0) {
+                continue;
+            }
+            message.sendCooldown = sendInterval;
+
+            // 构建消息
+            message.nbt = message.toNBT(sendPlayerPerMessage);
+            if (!message.nbt.isEmpty()) {
+                sendGamePlayer.clear();
+                sendGamePlayer.add(GameManager.get().getGamePlayerBySingleId(id));
+                if (serverLevel != null) {
+                    sendMessageToGamePlayers(sendGamePlayer, message.nbt, serverLevel);
+                }
+                // 消息还没发完
+                if (!message.isFinished()) {
+                    unfinishedId.add(id);
+                    continue;
+                }
+            }
+            // 消息发完就删了
+            messages.remove(id);
+        }
+        // 循环外统一添加
+        changedId.clear();
+        changedId.addAll(unfinishedId);
+    }
+
+    @Override
+    protected Function<Integer, SpectateMessage> createMessage() {
+        return (nbtId) -> new SpectateMessage(new CompoundTag(), currentTime, new ArrayList<>());
+    }
+}

--- a/src/main/java/xiao/battleroyale/common/message/team/TeamMessageManager.java
+++ b/src/main/java/xiao/battleroyale/common/message/team/TeamMessageManager.java
@@ -90,7 +90,7 @@ public class TeamMessageManager extends AbstractMessageManager<TeamMessage> {
         ServerLevel serverLevel = GameManager.get().getServerLevel();
 
         for (int id : changedId) {
-            GameTeam gameTeam = GameManager.get().getGameTeamById(id); // TeamManager内部做了特殊处理，不应该重新build消息时会防止MessageManager获取GameTeam
+            GameTeam gameTeam = GameManager.get().getGameTeamById(id); // TeamManager内部stopGame做了特殊处理，不应该重新build消息时会防止MessageManager获取GameTeam
             if (gameTeam != null) { // 队伍存在则计算NBT并发送
                 CompoundTag nbt = ClientTeamData.toNBT(gameTeam, serverLevel);
                 // 备份NBT和成员UUID

--- a/src/main/java/xiao/battleroyale/config/AbstractConfigManager.java
+++ b/src/main/java/xiao/battleroyale/config/AbstractConfigManager.java
@@ -270,7 +270,7 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
                     continue;
                 }
                 fileNameString = entry.getKey();
-                if (switchConfigFile(fileNameString, folderId)) { // 先切换到配置再应用默认
+                if (switchConfigFile(fileNameString, folderId)) { // 先切换到配置再覆盖应用默认
                     configEntry.applyDefault();
                     BattleRoyale.LOGGER.info("Applied default config, fileName:{}, configId:{}, type:{}", fileNameString, configEntry.getConfigId(), configEntry.getType());
                     return true;
@@ -350,6 +350,11 @@ public abstract class AbstractConfigManager<T extends IConfigSingleEntry> implem
             getConfigFileName(folderId).string = fileName;
             getConfigFolderData(folderId).currentConfigs.putAll(selectedFileConfigs.asMap());
             BattleRoyale.LOGGER.debug("Switched to config file '{}' for type: {}", fileName, getFolderType(folderId));
+            if (!selectedFileConfigs.isEmpty()) {
+                T configEntry = selectedFileConfigs.listGet(0);
+                configEntry.applyDefault();
+                BattleRoyale.LOGGER.debug("Applied first config while switching config file, fileName:{}, configId:{}, type:{}", fileName, configEntry.getConfigId(), configEntry.getType());
+            }
             return true;
         } else {
             BattleRoyale.LOGGER.warn("Config file '{}' not found for type {}", fileName, getFolderType(folderId));

--- a/src/main/java/xiao/battleroyale/config/client/render/defaultconfigs/DefaultRender.java
+++ b/src/main/java/xiao/battleroyale/config/client/render/defaultconfigs/DefaultRender.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import xiao.battleroyale.config.client.ClientConfigManager;
 import xiao.battleroyale.config.client.render.RenderConfigManager.RenderConfig;
 import xiao.battleroyale.config.client.render.type.BlockEntry;
+import xiao.battleroyale.config.client.render.type.SpectateEntry;
 import xiao.battleroyale.config.client.render.type.TeamEntry;
 import xiao.battleroyale.config.client.render.type.ZoneEntry;
 
@@ -29,8 +30,10 @@ public class DefaultRender {
         BlockEntry blockEntry = new BlockEntry(16);
         ZoneEntry zoneEntry = new ZoneEntry(false);
         TeamEntry teamEntry = new TeamEntry(true, false);
+        SpectateEntry spectateEntry = new SpectateEntry(true, false);
 
-        RenderConfig renderConfig = new RenderConfig(0, "No limit", "#FFFFFFAA", true, blockEntry, zoneEntry, teamEntry);
+        RenderConfig renderConfig = new RenderConfig(0, "No limit", "#FFFFFFAA", true,
+                blockEntry, zoneEntry, teamEntry, spectateEntry);
 
         return renderConfig.toJson();
     }
@@ -39,8 +42,10 @@ public class DefaultRender {
         BlockEntry blockEntry = new BlockEntry(0);
         ZoneEntry zoneEntry = new ZoneEntry(true, "#0000FF", 64, 64, 64, 64);
         TeamEntry teamEntry = new TeamEntry(true, true);
+        SpectateEntry spectateEntry = new SpectateEntry(true, true);
 
-        RenderConfig renderConfig = new RenderConfig(1, "Client single color", "#FFFFFFAA", blockEntry, zoneEntry, teamEntry);
+        RenderConfig renderConfig = new RenderConfig(1, "Client single color", "#FFFFFFAA",
+                blockEntry, zoneEntry, teamEntry, spectateEntry);
 
         return renderConfig.toJson();
     }
@@ -49,8 +54,10 @@ public class DefaultRender {
         BlockEntry blockEntry = new BlockEntry(8000);
         ZoneEntry zoneEntry = new ZoneEntry(false, "", 1024, 1024, 1024, 1024);
         TeamEntry teamEntry = new TeamEntry(true, false);
+        SpectateEntry spectateEntry = new SpectateEntry(true, false);
 
-        RenderConfig renderConfig = new RenderConfig(2, "Max render", "#FFFFFFAA", blockEntry, zoneEntry, teamEntry);
+        RenderConfig renderConfig = new RenderConfig(2, "Max render", "#FFFFFFAA",
+                blockEntry, zoneEntry, teamEntry, spectateEntry);
 
         return renderConfig.toJson();
     }
@@ -60,8 +67,11 @@ public class DefaultRender {
         ZoneEntry zoneEntry = new ZoneEntry(false, "", 32, 32, 32, 32);
         TeamEntry teamEntry = new TeamEntry(true, false, "",
                 false, true, 0.5F);
+        SpectateEntry spectateEntry = new SpectateEntry(true, false, "",
+                false, true, 0.5F, 20 * 5);
 
-        RenderConfig renderConfig = new RenderConfig(3, "Better Performance", "#FFFFFFAA", blockEntry, zoneEntry, teamEntry);
+        RenderConfig renderConfig = new RenderConfig(3, "Better Performance", "#FFFFFFAA",
+                blockEntry, zoneEntry, teamEntry, spectateEntry);
 
         return renderConfig.toJson();
     }

--- a/src/main/java/xiao/battleroyale/config/client/render/type/SpectateEntry.java
+++ b/src/main/java/xiao/battleroyale/config/client/render/type/SpectateEntry.java
@@ -1,0 +1,87 @@
+package xiao.battleroyale.config.client.render.type;
+
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
+import xiao.battleroyale.api.client.render.IRenderEntry;
+import xiao.battleroyale.api.client.render.RenderConfigTag;
+import xiao.battleroyale.client.renderer.game.SpectatePlayerRenderer;
+import xiao.battleroyale.util.JsonUtils;
+
+public class SpectateEntry implements IRenderEntry {
+
+    public final boolean enableSpectateRender;
+    public final boolean useClientColor;
+    public final String fixedColor;
+    public final boolean renderBeacon;
+    public final boolean renderBoundingBox;
+    public final float transparency;
+    public final int scanFrequency;
+
+    public SpectateEntry(boolean enableSpectateRender, boolean useClientColor) {
+        this(enableSpectateRender, useClientColor, "#00FFFF",
+                true, true, 0.5F, 60);
+    }
+
+    public SpectateEntry(boolean enableSpectateRender, boolean useClientColor, String fixedColor,
+                         boolean renderBeacon, boolean renderBoundingBox, float transparency, int scanFrequency) {
+        this.enableSpectateRender = enableSpectateRender;
+        this.useClientColor = useClientColor;
+        this.fixedColor = fixedColor;
+        this.renderBeacon = renderBeacon;
+        this.renderBoundingBox = renderBoundingBox;
+        this.transparency = transparency;
+        this.scanFrequency = scanFrequency;
+    }
+
+    @Override
+    public String getType() {
+        return "SpectateEntry";
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty(RenderConfigTag.ENABLE_SPECTATE_ZONE, enableSpectateRender);
+        if (!enableSpectateRender) {
+            return jsonObject;
+        }
+        jsonObject.addProperty(RenderConfigTag.USE_CLIENT_COLOR, useClientColor);
+        if (useClientColor) {
+            jsonObject.addProperty(RenderConfigTag.FIXED_COLOR, fixedColor);
+        }
+        jsonObject.addProperty(RenderConfigTag.RENDER_BEACON, renderBeacon);
+        jsonObject.addProperty(RenderConfigTag.RENDER_BOUNDING_BOX, renderBoundingBox);
+        jsonObject.addProperty(RenderConfigTag.TRANSPARENCY, transparency);
+        jsonObject.addProperty(RenderConfigTag.SCAN_FREQUENCY, scanFrequency);
+        return jsonObject;
+    }
+
+    @NotNull
+    public static SpectateEntry fromJson(JsonObject jsonObject) {
+        boolean enableSpectateRender = JsonUtils.getJsonBool(jsonObject, RenderConfigTag.ENABLE_SPECTATE_ZONE, true);
+        boolean useClientColor = JsonUtils.getJsonBool(jsonObject, RenderConfigTag.USE_CLIENT_COLOR, false);
+        String fixedColor = JsonUtils.getJsonString(jsonObject, RenderConfigTag.FIXED_COLOR, "");
+        boolean renderBeacon = JsonUtils.getJsonBool(jsonObject, RenderConfigTag.RENDER_BEACON, true);
+        boolean renderBoundingBox = JsonUtils.getJsonBool(jsonObject, RenderConfigTag.RENDER_BOUNDING_BOX, true);
+        float transparency = (float) JsonUtils.getJsonDouble(jsonObject, RenderConfigTag.TRANSPARENCY, 0.5);
+        int scanFrequency = JsonUtils.getJsonInt(jsonObject, RenderConfigTag.SCAN_FREQUENCY, 60);
+
+        return new SpectateEntry(enableSpectateRender, useClientColor, fixedColor,
+                renderBeacon, renderBoundingBox, transparency, scanFrequency);
+    }
+
+    @Override
+    public void applyDefault() {
+        SpectatePlayerRenderer.setEnableSpectateRender(enableSpectateRender);
+        if (enableSpectateRender) {
+            SpectatePlayerRenderer.setUseClientColor(useClientColor);
+            if (useClientColor) {
+                SpectatePlayerRenderer.setClientColorString(fixedColor);
+            }
+            SpectatePlayerRenderer.setRenderBeacon(renderBeacon);
+            SpectatePlayerRenderer.setRenderBoundingBox(renderBoundingBox);
+            SpectatePlayerRenderer.setTransparency(transparency);
+            SpectatePlayerRenderer.setScanFrequency(scanFrequency);
+        }
+    }
+}

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
@@ -1,11 +1,13 @@
 package xiao.battleroyale.config.common.game.gamerule.type;
 
 import com.google.gson.JsonObject;
+import net.minecraft.ChatFormatting;
 import org.jetbrains.annotations.NotNull;
 import xiao.battleroyale.api.IConfigAppliable;
 import xiao.battleroyale.api.game.gamerule.GameEntryTag;
 import xiao.battleroyale.api.game.gamerule.IGameruleEntry;
 import xiao.battleroyale.common.message.AbstractMessageManager;
+import xiao.battleroyale.util.ColorUtils;
 import xiao.battleroyale.util.JsonUtils;
 
 import java.util.Arrays;
@@ -17,8 +19,27 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
     public final int teamMsgExpireTimeSeconds;
     public final List<String> teamColors;
     public static final List<String> DEFAULT_TEAM_COLORS = Arrays.asList(
-            "#E9ECEC", "#F07613", "#BD44B3", "#3AAFD9", "#F8C627", "#70B919", "#ED8DAC", "#8E8E86",
-            "#A0A0A0", "#158991", "#792AAC", "#35399D", "#724728", "#546D1B", "#A02722", "#141519");
+            // 彩色（深），红蓝开头
+            ColorUtils.parseIntToStringRGB(ChatFormatting.DARK_RED.getColor()), // §4
+            ColorUtils.parseIntToStringRGB(ChatFormatting.DARK_BLUE.getColor()), // §1
+            ColorUtils.parseIntToStringRGB(ChatFormatting.GOLD.getColor()), // §6
+            ColorUtils.parseIntToStringRGB(ChatFormatting.DARK_PURPLE.getColor()), // §5
+            ColorUtils.parseIntToStringRGB(ChatFormatting.DARK_GREEN.getColor()), // §2
+            ColorUtils.parseIntToStringRGB(ChatFormatting.DARK_AQUA.getColor()), // §3
+            // 彩色（浅），红蓝开头
+            ColorUtils.parseIntToStringRGB(ChatFormatting.RED.getColor()), // §12
+            ColorUtils.parseIntToStringRGB(ChatFormatting.BLUE.getColor()), // §9
+            ColorUtils.parseIntToStringRGB(ChatFormatting.YELLOW.getColor()), // §14
+            ColorUtils.parseIntToStringRGB(ChatFormatting.LIGHT_PURPLE.getColor()), // §13
+            ColorUtils.parseIntToStringRGB(ChatFormatting.GREEN.getColor()), // §10
+            ColorUtils.parseIntToStringRGB(ChatFormatting.AQUA.getColor()), // §11
+            // 黑白
+            ColorUtils.parseIntToStringRGB(ChatFormatting.BLACK.getColor()), // §0
+            ColorUtils.parseIntToStringRGB(ChatFormatting.GRAY.getColor()), // §7
+            // 黑白
+            ColorUtils.parseIntToStringRGB(ChatFormatting.DARK_GRAY.getColor()), // §8
+            ColorUtils.parseIntToStringRGB(ChatFormatting.WHITE.getColor()) // §15
+    );
     public static final List<Float> DEFAULT_DOWN_DAMAGE = Arrays.asList(0.3333F, 0.4444F, 0.6667F, 1.3333F, 2F, 4F, 8F, 16F, 32F);
     public final boolean buildVanillaTeam;
     public final boolean hideVanillaTeamName;

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 public class GameEntry implements IGameruleEntry, IConfigAppliable {
 
+    public final boolean teleportWhenInitGame;
     public final int teamMsgExpireTimeSeconds;
     public final List<String> teamColors;
     public static final List<String> DEFAULT_TEAM_COLORS = Arrays.asList(
@@ -45,18 +46,19 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
     public final int messageSyncFreq;
 
     public GameEntry() {
-        this(300, DEFAULT_TEAM_COLORS,
+        this(true, 300, DEFAULT_TEAM_COLORS,
                 20 * 60, 20 * 10, false,
                 true, false, false, DEFAULT_DOWN_DAMAGE, 20, false, true, true,
                 true, true, true, false, 0, 0,
                 20 * 7, 20 * 5, 20 * 5);
     }
 
-    public GameEntry(int teamMsgExpireTimeSeconds, List<String> teamColors,
+    public GameEntry(boolean teleportWhenInitGame, int teamMsgExpireTimeSeconds, List<String> teamColors,
                      int maxPlayerInvalidTime, int maxBotInvalidTime, boolean removeInvalidTeam,
                      boolean healAllAtStart, boolean friendlyFire, boolean downFire, List<Float> downDamageList, int downDamageFrequency, boolean onlyGamePlayerSpectate, boolean spectateAfterTeam, boolean teleportInterfererToLobby,
                      boolean allowRemainingBot, boolean keepTeamAfterGame, boolean teleportAfterGame, boolean teleportWinnerAfterGame, int winnerFireworkId, int winnerParticleId,
                      int messageCleanFreq, int messageExpireTime, int messageSyncFreq) {
+        this.teleportWhenInitGame = teleportWhenInitGame;
         this.teamMsgExpireTimeSeconds = teamMsgExpireTimeSeconds;
         this.teamColors = teamColors;
         this.maxPlayerInvalidTime = maxPlayerInvalidTime;
@@ -89,6 +91,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
     @Override
     public JsonObject toJson() {
         JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty(GameEntryTag.TELEPORT_WHEN_INIT_GAME, teleportWhenInitGame);
         jsonObject.addProperty(GameEntryTag.TEAM_MSG_EXPIRE_SECONDS, teamMsgExpireTimeSeconds);
         jsonObject.add(GameEntryTag.TEAM_COLORS, JsonUtils.writeStringListToJson(teamColors));
 
@@ -120,6 +123,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
 
     @NotNull
     public static GameEntry fromJson(JsonObject jsonObject) {
+        boolean teleportWhenInitGame = JsonUtils.getJsonBool(jsonObject, GameEntryTag.TELEPORT_WHEN_INIT_GAME, true);
         int teamMsgExpireTimeSeconds = JsonUtils.getJsonInt(jsonObject, GameEntryTag.TEAM_MSG_EXPIRE_SECONDS, 300);
         List<String> teamColors = JsonUtils.getJsonStringList(jsonObject, GameEntryTag.TEAM_COLORS);
 
@@ -147,7 +151,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         int messageExpireTime = JsonUtils.getJsonInt(jsonObject, GameEntryTag.MESSAGE_EXPIRE_TIME, 20 * 5);
         int messageSyncFreq = JsonUtils.getJsonInt(jsonObject, GameEntryTag.MESSAGE_FORCE_SYNC_FREQUENCY, 20 * 5);
 
-        return new GameEntry(teamMsgExpireTimeSeconds, teamColors,
+        return new GameEntry(teleportWhenInitGame, teamMsgExpireTimeSeconds, teamColors,
                 maxInvalidTime, maxBotInvalidTime, removeInvalidTeam,
                 healAllAtStart, friendlyFire, downFire, downDamageList, downDamageFrequency, onlyGamePlayerSpectate, spectateAfterTeam, teleportInterfererToLobby,
                 allowRemainingBot, keepTeamAfterGame, teleportAfterGame, teleportWinnerAfterGame, winnerFireworkId, winnerParticleId,

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
@@ -20,6 +20,8 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
             "#E9ECEC", "#F07613", "#BD44B3", "#3AAFD9", "#F8C627", "#70B919", "#ED8DAC", "#8E8E86",
             "#A0A0A0", "#158991", "#792AAC", "#35399D", "#724728", "#546D1B", "#A02722", "#141519");
     public static final List<Float> DEFAULT_DOWN_DAMAGE = Arrays.asList(0.3333F, 0.4444F, 0.6667F, 1.3333F, 2F, 4F, 8F, 16F, 32F);
+    public final boolean buildVanillaTeam;
+    public final boolean hideVanillaTeamName;
 
     public final int maxPlayerInvalidTime;
     public final int maxBotInvalidTime;
@@ -48,14 +50,14 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
     public final int messageSyncFreq;
 
     public GameEntry() {
-        this(true, 300, DEFAULT_TEAM_COLORS,
+        this(true, 300, DEFAULT_TEAM_COLORS, true, true,
                 20 * 60, 20 * 10, false,
                 true, false, false, DEFAULT_DOWN_DAMAGE, 20, false, true, true, true,
                 true, true, true, false, 0, 0, false,
                 20 * 7, 20 * 5, 20 * 5);
     }
 
-    public GameEntry(boolean teleportWhenInitGame, int teamMsgExpireTimeSeconds, List<String> teamColors,
+    public GameEntry(boolean teleportWhenInitGame, int teamMsgExpireTimeSeconds, List<String> teamColors, boolean buildVanillaTeam, boolean hideVanillaTeamName,
                      int maxPlayerInvalidTime, int maxBotInvalidTime, boolean removeInvalidTeam,
                      boolean healAllAtStart, boolean friendlyFire, boolean downFire, List<Float> downDamageList, int downDamageFrequency,
                      boolean onlyGamePlayerSpectate, boolean spectateAfterTeam, boolean spectatorSeeAllTeams, boolean teleportInterfererToLobby,
@@ -64,6 +66,8 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         this.teleportWhenInitGame = teleportWhenInitGame;
         this.teamMsgExpireTimeSeconds = teamMsgExpireTimeSeconds;
         this.teamColors = teamColors;
+        this.buildVanillaTeam = buildVanillaTeam;
+        this.hideVanillaTeamName = hideVanillaTeamName;
         this.maxPlayerInvalidTime = maxPlayerInvalidTime;
         this.maxBotInvalidTime = maxBotInvalidTime;
         this.removeInvalidTeam = removeInvalidTeam;
@@ -99,6 +103,8 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         jsonObject.addProperty(GameEntryTag.TELEPORT_WHEN_INIT_GAME, teleportWhenInitGame);
         jsonObject.addProperty(GameEntryTag.TEAM_MSG_EXPIRE_SECONDS, teamMsgExpireTimeSeconds);
         jsonObject.add(GameEntryTag.TEAM_COLORS, JsonUtils.writeStringListToJson(teamColors));
+        jsonObject.addProperty(GameEntryTag.BUILD_VANILLA_TEAM, buildVanillaTeam);
+        jsonObject.addProperty(GameEntryTag.HIDE_VANILLA_TEAM_NAME, hideVanillaTeamName);
 
         jsonObject.addProperty(GameEntryTag.MAX_PLAYER_INVALID_TIME, maxPlayerInvalidTime);
         jsonObject.addProperty(GameEntryTag.MAX_BOT_INVALID_TIME, maxBotInvalidTime);
@@ -133,6 +139,8 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         boolean teleportWhenInitGame = JsonUtils.getJsonBool(jsonObject, GameEntryTag.TELEPORT_WHEN_INIT_GAME, true);
         int teamMsgExpireTimeSeconds = JsonUtils.getJsonInt(jsonObject, GameEntryTag.TEAM_MSG_EXPIRE_SECONDS, 300);
         List<String> teamColors = JsonUtils.getJsonStringList(jsonObject, GameEntryTag.TEAM_COLORS);
+        boolean buildVanillaTeam = JsonUtils.getJsonBool(jsonObject, GameEntryTag.BUILD_VANILLA_TEAM, true);
+        boolean hideVanillaTeamName = JsonUtils.getJsonBool(jsonObject, GameEntryTag.HIDE_VANILLA_TEAM_NAME, true);
 
         int maxInvalidTime = JsonUtils.getJsonInt(jsonObject, GameEntryTag.MAX_PLAYER_INVALID_TIME, 20 * 60);
         int maxBotInvalidTime = JsonUtils.getJsonInt(jsonObject, GameEntryTag.MAX_BOT_INVALID_TIME, 20 * 10);
@@ -160,7 +168,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         int messageExpireTime = JsonUtils.getJsonInt(jsonObject, GameEntryTag.MESSAGE_EXPIRE_TIME, 20 * 5);
         int messageSyncFreq = JsonUtils.getJsonInt(jsonObject, GameEntryTag.MESSAGE_FORCE_SYNC_FREQUENCY, 20 * 5);
 
-        return new GameEntry(teleportWhenInitGame, teamMsgExpireTimeSeconds, teamColors,
+        return new GameEntry(teleportWhenInitGame, teamMsgExpireTimeSeconds, teamColors, buildVanillaTeam, hideVanillaTeamName,
                 maxInvalidTime, maxBotInvalidTime, removeInvalidTeam,
                 healAllAtStart, friendlyFire, downFire, downDamageList, downDamageFrequency,
                 onlyGamePlayerSpectate, spectateAfterTeam, spectatorSeeAllTeams, teleportInterfererToLobby,

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
@@ -32,6 +32,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
     public final int downDamageFrequency;
     public final boolean onlyGamePlayerSpectate;
     public final boolean spectateAfterTeam;
+    public final boolean spectatorSeeAllTeams;
     public final boolean teleportInterfererToLobby;
 
     public final boolean allowRemainingBot;
@@ -49,14 +50,15 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
     public GameEntry() {
         this(true, 300, DEFAULT_TEAM_COLORS,
                 20 * 60, 20 * 10, false,
-                true, false, false, DEFAULT_DOWN_DAMAGE, 20, false, true, true,
+                true, false, false, DEFAULT_DOWN_DAMAGE, 20, false, true, true, true,
                 true, true, true, false, 0, 0, false,
                 20 * 7, 20 * 5, 20 * 5);
     }
 
     public GameEntry(boolean teleportWhenInitGame, int teamMsgExpireTimeSeconds, List<String> teamColors,
                      int maxPlayerInvalidTime, int maxBotInvalidTime, boolean removeInvalidTeam,
-                     boolean healAllAtStart, boolean friendlyFire, boolean downFire, List<Float> downDamageList, int downDamageFrequency, boolean onlyGamePlayerSpectate, boolean spectateAfterTeam, boolean teleportInterfererToLobby,
+                     boolean healAllAtStart, boolean friendlyFire, boolean downFire, List<Float> downDamageList, int downDamageFrequency,
+                     boolean onlyGamePlayerSpectate, boolean spectateAfterTeam, boolean spectatorSeeAllTeams, boolean teleportInterfererToLobby,
                      boolean allowRemainingBot, boolean keepTeamAfterGame, boolean teleportAfterGame, boolean teleportWinnerAfterGame, int winnerFireworkId, int winnerParticleId, boolean initGameAfterGame,
                      int messageCleanFreq, int messageExpireTime, int messageSyncFreq) {
         this.teleportWhenInitGame = teleportWhenInitGame;
@@ -72,6 +74,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         this.downDamageFrequency = downDamageFrequency;
         this.onlyGamePlayerSpectate = onlyGamePlayerSpectate;
         this.spectateAfterTeam = spectateAfterTeam;
+        this.spectatorSeeAllTeams = spectatorSeeAllTeams;
         this.teleportInterfererToLobby = teleportInterfererToLobby;
         this.allowRemainingBot = allowRemainingBot;
         this.keepTeamAfterGame = keepTeamAfterGame;
@@ -108,6 +111,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         jsonObject.addProperty(GameEntryTag.DOWN_DAMAGE_FREQUENCY, downDamageFrequency);
         jsonObject.addProperty(GameEntryTag.ONLY_GAME_PLAYER_SPECTATE, onlyGamePlayerSpectate);
         jsonObject.addProperty(GameEntryTag.SPECTATE_AFTER_TEAM, spectateAfterTeam);
+        jsonObject.addProperty(GameEntryTag.SPECTATOR_SEE_ALL_TEAMS, spectatorSeeAllTeams);
         jsonObject.addProperty(GameEntryTag.TELEPORT_INTERFERER_TO_LOBBY, teleportInterfererToLobby);
 
         jsonObject.addProperty(GameEntryTag.ALLOW_REMAINING_BOT, allowRemainingBot);
@@ -141,6 +145,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         int downDamageFrequency = JsonUtils.getJsonInt(jsonObject, GameEntryTag.DOWN_DAMAGE_FREQUENCY, 20);
         boolean onlyGamePlayerSpectate = JsonUtils.getJsonBool(jsonObject, GameEntryTag.ONLY_GAME_PLAYER_SPECTATE, false);
         boolean spectateAfterTeam = JsonUtils.getJsonBool(jsonObject, GameEntryTag.SPECTATE_AFTER_TEAM, true);
+        boolean spectatorSeeAllTeams = JsonUtils.getJsonBool(jsonObject, GameEntryTag.SPECTATOR_SEE_ALL_TEAMS, true);
         boolean teleportInterfererToLobby = JsonUtils.getJsonBool(jsonObject, GameEntryTag.TELEPORT_INTERFERER_TO_LOBBY, true);
 
         boolean allowRemainingBot = JsonUtils.getJsonBool(jsonObject, GameEntryTag.ALLOW_REMAINING_BOT, false);
@@ -157,7 +162,8 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
 
         return new GameEntry(teleportWhenInitGame, teamMsgExpireTimeSeconds, teamColors,
                 maxInvalidTime, maxBotInvalidTime, removeInvalidTeam,
-                healAllAtStart, friendlyFire, downFire, downDamageList, downDamageFrequency, onlyGamePlayerSpectate, spectateAfterTeam, teleportInterfererToLobby,
+                healAllAtStart, friendlyFire, downFire, downDamageList, downDamageFrequency,
+                onlyGamePlayerSpectate, spectateAfterTeam, spectatorSeeAllTeams, teleportInterfererToLobby,
                 allowRemainingBot, keepTeamAfterGame, teleportAfterGame, teleportWinnerAfterGame, winnerFireworkId, winnerParticleId, initGameAfterGame,
                 messageCleanFreq, messageExpireTime, messageSyncFreq);
     }

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
@@ -26,6 +26,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
 
     public final boolean healAllAtStart;
     public final boolean friendlyFire;
+    public final boolean downFire;
     public final List<Float> downDamageList;
     public final int downDamageFrequency;
     public final boolean onlyGamePlayerSpectate;
@@ -46,14 +47,14 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
     public GameEntry() {
         this(300, DEFAULT_TEAM_COLORS,
                 20 * 60, 20 * 10, false,
-                true, false, DEFAULT_DOWN_DAMAGE, 20, false, true, true,
+                true, false, false, DEFAULT_DOWN_DAMAGE, 20, false, true, true,
                 true, true, true, false, 0, 0,
                 20 * 7, 20 * 5, 20 * 5);
     }
 
     public GameEntry(int teamMsgExpireTimeSeconds, List<String> teamColors,
                      int maxPlayerInvalidTime, int maxBotInvalidTime, boolean removeInvalidTeam,
-                     boolean healAllAtStart, boolean friendlyFire, List<Float> downDamageList, int downDamageFrequency, boolean onlyGamePlayerSpectate, boolean spectateAfterTeam, boolean teleportInterfererToLobby,
+                     boolean healAllAtStart, boolean friendlyFire, boolean downFire, List<Float> downDamageList, int downDamageFrequency, boolean onlyGamePlayerSpectate, boolean spectateAfterTeam, boolean teleportInterfererToLobby,
                      boolean allowRemainingBot, boolean keepTeamAfterGame, boolean teleportAfterGame, boolean teleportWinnerAfterGame, int winnerFireworkId, int winnerParticleId,
                      int messageCleanFreq, int messageExpireTime, int messageSyncFreq) {
         this.teamMsgExpireTimeSeconds = teamMsgExpireTimeSeconds;
@@ -63,6 +64,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         this.removeInvalidTeam = removeInvalidTeam;
         this.healAllAtStart = healAllAtStart;
         this.friendlyFire = friendlyFire;
+        this.downFire = downFire;
         this.downDamageList = downDamageList;
         this.downDamageFrequency = downDamageFrequency;
         this.onlyGamePlayerSpectate = onlyGamePlayerSpectate;
@@ -96,6 +98,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
 
         jsonObject.addProperty(GameEntryTag.HEAL_ALL_AT_START, healAllAtStart);
         jsonObject.addProperty(GameEntryTag.FRIENDLY_FIRE, friendlyFire);
+        jsonObject.addProperty(GameEntryTag.DOWN_FIRE, downFire);
         jsonObject.add(GameEntryTag.DOWN_DAMAGE_LIST, JsonUtils.writeFloatListToJson(downDamageList));
         jsonObject.addProperty(GameEntryTag.DOWN_DAMAGE_FREQUENCY, downDamageFrequency);
         jsonObject.addProperty(GameEntryTag.ONLY_GAME_PLAYER_SPECTATE, onlyGamePlayerSpectate);
@@ -126,6 +129,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
 
         boolean healAllAtStart = JsonUtils.getJsonBool(jsonObject, GameEntryTag.HEAL_ALL_AT_START, true);
         boolean friendlyFire = JsonUtils.getJsonBool(jsonObject, GameEntryTag.FRIENDLY_FIRE, false);
+        boolean downFire = JsonUtils.getJsonBool(jsonObject, GameEntryTag.DOWN_FIRE, false);
         List<Float> downDamageList = JsonUtils.getJsonFloatList(jsonObject, GameEntryTag.DOWN_DAMAGE_LIST);
         int downDamageFrequency = JsonUtils.getJsonInt(jsonObject, GameEntryTag.DOWN_DAMAGE_FREQUENCY, 20);
         boolean onlyGamePlayerSpectate = JsonUtils.getJsonBool(jsonObject, GameEntryTag.ONLY_GAME_PLAYER_SPECTATE, false);
@@ -145,7 +149,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
 
         return new GameEntry(teamMsgExpireTimeSeconds, teamColors,
                 maxInvalidTime, maxBotInvalidTime, removeInvalidTeam,
-                healAllAtStart, friendlyFire, downDamageList, downDamageFrequency, onlyGamePlayerSpectate, spectateAfterTeam, teleportInterfererToLobby,
+                healAllAtStart, friendlyFire, downFire, downDamageList, downDamageFrequency, onlyGamePlayerSpectate, spectateAfterTeam, teleportInterfererToLobby,
                 allowRemainingBot, keepTeamAfterGame, teleportAfterGame, teleportWinnerAfterGame, winnerFireworkId, winnerParticleId,
                 messageCleanFreq, messageExpireTime, messageSyncFreq);
     }

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
@@ -40,6 +40,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
     public final boolean teleportWinnerAfterGame;
     public final int winnerFireworkId;
     public final int winnerParticleId;
+    public final boolean initGameAfterGame;
 
     public final int messageCleanFreq;
     public final int messageExpireTime;
@@ -49,14 +50,14 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         this(true, 300, DEFAULT_TEAM_COLORS,
                 20 * 60, 20 * 10, false,
                 true, false, false, DEFAULT_DOWN_DAMAGE, 20, false, true, true,
-                true, true, true, false, 0, 0,
+                true, true, true, false, 0, 0, false,
                 20 * 7, 20 * 5, 20 * 5);
     }
 
     public GameEntry(boolean teleportWhenInitGame, int teamMsgExpireTimeSeconds, List<String> teamColors,
                      int maxPlayerInvalidTime, int maxBotInvalidTime, boolean removeInvalidTeam,
                      boolean healAllAtStart, boolean friendlyFire, boolean downFire, List<Float> downDamageList, int downDamageFrequency, boolean onlyGamePlayerSpectate, boolean spectateAfterTeam, boolean teleportInterfererToLobby,
-                     boolean allowRemainingBot, boolean keepTeamAfterGame, boolean teleportAfterGame, boolean teleportWinnerAfterGame, int winnerFireworkId, int winnerParticleId,
+                     boolean allowRemainingBot, boolean keepTeamAfterGame, boolean teleportAfterGame, boolean teleportWinnerAfterGame, int winnerFireworkId, int winnerParticleId, boolean initGameAfterGame,
                      int messageCleanFreq, int messageExpireTime, int messageSyncFreq) {
         this.teleportWhenInitGame = teleportWhenInitGame;
         this.teamMsgExpireTimeSeconds = teamMsgExpireTimeSeconds;
@@ -78,6 +79,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         this.teleportWinnerAfterGame = teleportWinnerAfterGame;
         this.winnerFireworkId = winnerFireworkId;
         this.winnerParticleId = winnerParticleId;
+        this.initGameAfterGame = initGameAfterGame;
         this.messageCleanFreq = messageCleanFreq;
         this.messageExpireTime = messageExpireTime;
         this.messageSyncFreq = messageSyncFreq;
@@ -114,6 +116,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         jsonObject.addProperty(GameEntryTag.TELEPORT_WINNER_AFTER_GAME, teleportWinnerAfterGame);
         jsonObject.addProperty(GameEntryTag.WINNER_FIREWORK_ID, winnerFireworkId);
         jsonObject.addProperty(GameEntryTag.WINNER_PARTICLE_ID, winnerParticleId);
+        jsonObject.addProperty(GameEntryTag.INIT_GAME_AFTER_GAME, initGameAfterGame);
 
         jsonObject.addProperty(GameEntryTag.MESSAGE_CLEAN_FREQUENCY, messageCleanFreq);
         jsonObject.addProperty(GameEntryTag.MESSAGE_EXPIRE_TIME, messageExpireTime);
@@ -146,6 +149,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         boolean teleportWinnerAfterGame = JsonUtils.getJsonBool(jsonObject, GameEntryTag.TELEPORT_WINNER_AFTER_GAME, false);
         int winnerFireworkId = JsonUtils.getJsonInt(jsonObject, GameEntryTag.WINNER_FIREWORK_ID, 0);
         int winnerParticleId = JsonUtils.getJsonInt(jsonObject, GameEntryTag.WINNER_PARTICLE_ID, 0);
+        boolean initGameAfterGame = JsonUtils.getJsonBool(jsonObject, GameEntryTag.INIT_GAME_AFTER_GAME, false);
 
         int messageCleanFreq = JsonUtils.getJsonInt(jsonObject, GameEntryTag.MESSAGE_CLEAN_FREQUENCY, 20 * 7);
         int messageExpireTime = JsonUtils.getJsonInt(jsonObject, GameEntryTag.MESSAGE_EXPIRE_TIME, 20 * 5);
@@ -154,7 +158,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         return new GameEntry(teleportWhenInitGame, teamMsgExpireTimeSeconds, teamColors,
                 maxInvalidTime, maxBotInvalidTime, removeInvalidTeam,
                 healAllAtStart, friendlyFire, downFire, downDamageList, downDamageFrequency, onlyGamePlayerSpectate, spectateAfterTeam, teleportInterfererToLobby,
-                allowRemainingBot, keepTeamAfterGame, teleportAfterGame, teleportWinnerAfterGame, winnerFireworkId, winnerParticleId,
+                allowRemainingBot, keepTeamAfterGame, teleportAfterGame, teleportWinnerAfterGame, winnerFireworkId, winnerParticleId, initGameAfterGame,
                 messageCleanFreq, messageExpireTime, messageSyncFreq);
     }
 

--- a/src/main/java/xiao/battleroyale/developer/debug/DebugMessage.java
+++ b/src/main/java/xiao/battleroyale/developer/debug/DebugMessage.java
@@ -9,6 +9,8 @@ import xiao.battleroyale.client.game.data.ClientSingleZoneData;
 import xiao.battleroyale.client.game.data.ClientTeamData;
 import xiao.battleroyale.client.game.data.TeamMemberInfo;
 import xiao.battleroyale.common.message.game.GameMessageManager;
+import xiao.battleroyale.common.message.game.SpectateMessage;
+import xiao.battleroyale.common.message.game.SpectateMessageManager;
 import xiao.battleroyale.common.message.team.TeamMessageManager;
 import xiao.battleroyale.common.message.zone.ZoneMessage;
 import xiao.battleroyale.common.message.zone.ZoneMessageManager;
@@ -100,6 +102,29 @@ public class DebugMessage {
                 .toList();
         DebugManager.sendLocalDebugMessage(source, GET_GAME_MESSAGES, MessageText.buildGameMessagesDetailLocal(keyList));
     }
+    public static final String GET_SPECTATE_MESSAGES = "getSpectateMessages";
+    public void getSpectateMessages(CommandSourceStack source, int min, int max) {
+        List<Integer> idList = SpectateMessageManager.get().getMessagesIdList().stream()
+                .filter(id -> id >= min && id <= max)
+                .sorted()
+                .toList();
+        DebugManager.sendDebugMessage(source, GET_SPECTATE_MESSAGES, MessageText.buildSpectateMessagesDetail(SpectateMessageManager.get(), idList));
+    }
+    public void getSpectateMessagesLocal(CommandSourceStack source, int min, int max) {
+        CompoundTag messageNbt = ClientGameDataManager.get().getGameData().getSpectateData().lastMessageNbt;
+        List<String> keyList = messageNbt.getAllKeys().stream()
+                .filter(keyString -> {
+                    try {
+                        int keyInt = Integer.parseInt(keyString);
+                        return keyInt >= min && keyInt <= max;
+                    } catch (NumberFormatException e) {
+                        return false;
+                    }
+                })
+                .sorted()
+                .toList();
+        DebugManager.sendLocalDebugMessage(source, GET_SPECTATE_MESSAGES, MessageText.buildSpectateMessagesDetailLocal(keyList));
+    }
 
     /**
      * [调试]getZoneMessage:
@@ -171,5 +196,21 @@ public class DebugMessage {
             }
         }
         DebugManager.sendLocalDebugMessage(source, GET_GAME_MESSAGE, MessageText.buildGameMessageDetailLocal(nbt, (int) gameData.getLastUpdateTick()));
+    }
+    public static final String GET_SPECTATE_MESSAGE = "getSpectateMessage";
+    public void getSpectateMessage(CommandSourceStack source, int nbtId) {
+        DebugManager.sendDebugMessage(source, GET_SPECTATE_MESSAGE, MessageText.buildSpectateMessageDetail(SpectateMessageManager.get().getMessage(nbtId), nbtId));
+    }
+    public void getSpectateMessageLocal(CommandSourceStack source, int nbtId) {
+        ClientGameData.ClientSpectateData spectateData = ClientGameDataManager.get().getGameData().getSpectateData();
+        CompoundTag messageNbt = spectateData.lastMessageNbt;
+        CompoundTag nbt = null;
+        String nbtIdString = Integer.toString(nbtId);
+        for (String key : messageNbt.getAllKeys()) {
+            if (key.equals(nbtIdString)) {
+                nbt = messageNbt.getCompound(key);
+            }
+        }
+        DebugManager.sendLocalDebugMessage(source, GET_SPECTATE_MESSAGE, MessageText.buildSpectateMessageDetailLocal(nbt, (int) spectateData.getLastUpdateTick()));
     }
 }

--- a/src/main/java/xiao/battleroyale/developer/debug/DebugMessage.java
+++ b/src/main/java/xiao/battleroyale/developer/debug/DebugMessage.java
@@ -2,6 +2,7 @@ package xiao.battleroyale.developer.debug;
 
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.nbt.CompoundTag;
+import xiao.battleroyale.BattleRoyale;
 import xiao.battleroyale.api.message.zone.GameZoneTag;
 import xiao.battleroyale.client.game.ClientGameDataManager;
 import xiao.battleroyale.client.game.data.ClientGameData;

--- a/src/main/java/xiao/battleroyale/developer/debug/command/CommandArg.java
+++ b/src/main/java/xiao/battleroyale/developer/debug/command/CommandArg.java
@@ -81,6 +81,10 @@ public class CommandArg {
     public static final String GAME_MESSAGES_SHORT = "gmsgs";
     public static final String GAME_MESSAGE = "gamemessage";
     public static final String GAME_MESSAGE_SHORT = "gmsg";
+    public static final String SPECTATE_MESSAGES = "spectatemessages";
+    public static final String SPECTATE_MESSAGES_SHORT = "smsgs";
+    public static final String SPECTATE_MESSAGE = "spectatemessage";
+    public static final String SPECTATE_MESSAGE_SHORT = "smsg";
     // Effect
     public static final String CHANNEL = "channel";
     public static final String PARTICLES = "particles";

--- a/src/main/java/xiao/battleroyale/developer/debug/command/sub/get/GetMessage.java
+++ b/src/main/java/xiao/battleroyale/developer/debug/command/sub/get/GetMessage.java
@@ -146,7 +146,7 @@ public class GetMessage {
         // get spectatemessages [min max / all]
         getCommand.then(Commands.literal(useFullName ? SPECTATE_MESSAGES : SPECTATE_MESSAGES_SHORT)
                 .then(Commands.literal(ALL)
-                        .executes(context -> localGetSpectateMessages(context, Integer.MAX_VALUE, Integer.MAX_VALUE - 1)))
+                        .executes(context -> localGetSpectateMessages(context, Integer.MIN_VALUE, Integer.MAX_VALUE - 1)))
                 .then(Commands.argument(ID_MIN, IntegerArgumentType.integer())
                         .then(Commands.argument(ID_MAX, IntegerArgumentType.integer())
                                 .executes(context -> localGetSpectateMessages(context,

--- a/src/main/java/xiao/battleroyale/developer/debug/command/sub/get/GetMessage.java
+++ b/src/main/java/xiao/battleroyale/developer/debug/command/sub/get/GetMessage.java
@@ -9,6 +9,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
+import xiao.battleroyale.common.message.game.SpectateMessage;
 import xiao.battleroyale.developer.debug.DebugManager;
 import xiao.battleroyale.developer.debug.DebugMessage;
 import xiao.battleroyale.developer.debug.LocalDebugManager;
@@ -72,6 +73,21 @@ public class GetMessage {
         getCommand.then(Commands.literal(useFullName ? GAME_MESSAGE : GAME_MESSAGE_SHORT)
                 .then(Commands.argument(SINGLE_ID, IntegerArgumentType.integer())
                         .executes(GetMessage::getGameMessage)));
+
+        // 获取观战消息
+        // get spectatemessages [min max / all]
+        getCommand.then(Commands.literal(useFullName ? SPECTATE_MESSAGES : SPECTATE_MESSAGES_SHORT)
+                .then(Commands.literal(ALL)
+                        .executes(context -> getSpectateMessages(context, Integer.MIN_VALUE, Integer.MAX_VALUE - 1)))
+                .then(Commands.argument(ID_MIN, IntegerArgumentType.integer())
+                        .then(Commands.argument(ID_MAX, IntegerArgumentType.integer())
+                                .executes(context -> getSpectateMessages(context,
+                                        IntegerArgumentType.getInteger(context, ID_MIN),
+                                        IntegerArgumentType.getInteger(context, ID_MAX))))));
+        // get spectatemessage [id]
+        getCommand.then(Commands.literal(useFullName ? SPECTATE_MESSAGE : SPECTATE_MESSAGE_SHORT)
+                .then(Commands.argument(SINGLE_ID, IntegerArgumentType.integer())
+                        .executes(GetMessage::getSpectateMessage)));
     }
 
     public static void addClient(LiteralArgumentBuilder<CommandSourceStack> getCommand, boolean useFullName) {
@@ -125,6 +141,21 @@ public class GetMessage {
         getCommand.then(Commands.literal(useFullName ? GAME_MESSAGE : GAME_MESSAGE_SHORT)
                 .then(Commands.argument(SINGLE_ID, IntegerArgumentType.integer())
                         .executes(GetMessage::localGetGameMessage)));
+
+        // 显示观战消息
+        // get spectatemessages [min max / all]
+        getCommand.then(Commands.literal(useFullName ? SPECTATE_MESSAGES : SPECTATE_MESSAGES_SHORT)
+                .then(Commands.literal(ALL)
+                        .executes(context -> localGetSpectateMessages(context, Integer.MAX_VALUE, Integer.MAX_VALUE - 1)))
+                .then(Commands.argument(ID_MIN, IntegerArgumentType.integer())
+                        .then(Commands.argument(ID_MAX, IntegerArgumentType.integer())
+                                .executes(context -> localGetSpectateMessages(context,
+                                        IntegerArgumentType.getInteger(context, ID_MIN),
+                                        IntegerArgumentType.getInteger(context, ID_MAX))))));
+        // get spectatemessage [id]
+        getCommand.then(Commands.literal(useFullName ? SPECTATE_MESSAGE : SPECTATE_MESSAGE_SHORT)
+                .then(Commands.argument(SINGLE_ID, IntegerArgumentType.integer())
+                        .executes(GetMessage::localGetSpectateMessage)));
     }
 
     /**
@@ -319,6 +350,54 @@ public class GetMessage {
         return Command.SINGLE_SUCCESS;
     }
 
+    /**
+     * 获取观战消息
+     */
+    private static int getSpectateMessages(CommandContext<CommandSourceStack> context, int min, int max) {
+        CommandSourceStack source = context.getSource();
+        if (!DebugManager.hasDebugPermission(source)) {
+            context.getSource().sendFailure(Component.translatable("battleroyale.message.no_debug_permission"));
+            return 0;
+        }
+
+        DebugMessage.get().getSpectateMessages(source, min, max);
+        return Command.SINGLE_SUCCESS;
+    }
+    private static int getSpectateMessage(CommandContext<CommandSourceStack> context) {
+        CommandSourceStack source = context.getSource();
+        if (!DebugManager.hasDebugPermission(source)) {
+            context.getSource().sendFailure(Component.translatable("battleroyale.message.no_debug_permission"));
+            return 0;
+        }
+
+        DebugMessage.get().getSpectateMessage(source, IntegerArgumentType.getInteger(context, SINGLE_ID));
+        return Command.SINGLE_SUCCESS;
+    }
+    private static int localGetSpectateMessages(CommandContext<CommandSourceStack> context, int min, int max) {
+        CommandSourceStack source = context.getSource();
+        if (!LocalDebugManager.enableLocalDebug(source)) {
+            source.sendFailure(Component.translatable("battleroyale.message.local_debug_not_enabled"));
+            return 0;
+        }
+
+        if (Minecraft.getInstance().player != null) {
+            DebugMessage.get().getSpectateMessagesLocal(source, min, max);
+        }
+        return Command.SINGLE_SUCCESS;
+    }
+    private static int localGetSpectateMessage(CommandContext<CommandSourceStack> context) {
+        CommandSourceStack source = context.getSource();
+        if (!LocalDebugManager.enableLocalDebug(source)) {
+            source.sendFailure(Component.translatable("battleroyale.message.local_debug_not_enabled"));
+            return 0;
+        }
+
+        if (Minecraft.getInstance().player != null) {
+            DebugMessage.get().getSpectateMessageLocal(source, IntegerArgumentType.getInteger(context, SINGLE_ID));
+        }
+        return Command.SINGLE_SUCCESS;
+    }
+
     public static String getZoneMessagesCommand(int min, int max) {
         return buildDebugCommandString(
                 GET,
@@ -364,6 +443,21 @@ public class GetMessage {
                 Integer.toString(channel)
         );
     }
+    public static String getSpectateMessagesCommand(int min, int max) {
+        return buildDebugCommandString(
+                GET,
+                SPECTATE_MESSAGE,
+                Integer.toString(min),
+                Integer.toString(max)
+        );
+    }
+    public static String getSpectateMessageCommand(int singleId) {
+        return buildDebugCommandString(
+                GET,
+                SPECTATE_MESSAGE,
+                Integer.toString(singleId)
+        );
+    }
 
     public static String getLocalZoneMessagesCommand(int min, int max) {
         return buildLocalDebugCommandString(
@@ -407,6 +501,21 @@ public class GetMessage {
         return buildLocalDebugCommandString(
                 GET,
                 GAME_MESSAGE,
+                Integer.toString(channel)
+        );
+    }
+    public static String getLocalSpectateMessagesCommand(int min, int max) {
+        return buildLocalDebugCommandString(
+                GET,
+                SPECTATE_MESSAGES,
+                Integer.toString(min),
+                Integer.toString(max)
+        );
+    }
+    public static String getLocalSpectateMessageCommand(int channel) {
+        return buildLocalDebugCommandString(
+                GET,
+                SPECTATE_MESSAGE,
                 Integer.toString(channel)
         );
     }

--- a/src/main/java/xiao/battleroyale/developer/debug/text/MessageText.java
+++ b/src/main/java/xiao/battleroyale/developer/debug/text/MessageText.java
@@ -58,7 +58,7 @@ public class MessageText {
                 .append(Component.literal(" "))
                 .append(buildGameMessagesSimpleLocal(clientGameDataManager))
                 .append(Component.literal(" "))
-                .append(buildSpectateMessageSimpleLocal(clientGameDataManager));
+                .append(buildSpectateMessagesSimpleLocal(clientGameDataManager));
 
         return component;
     }
@@ -99,7 +99,7 @@ public class MessageText {
         String command = GetMessage.getLocalGameMessagesCommand(-10, 0);
         return buildMessagesCommonSimpleLocal(size, command, "GameMessages");
     }
-    public static MutableComponent buildSpectateMessageSimpleLocal(ClientGameDataManager clientGameDataManager) {
+    public static MutableComponent buildSpectateMessagesSimpleLocal(ClientGameDataManager clientGameDataManager) {
         int size = clientGameDataManager.getGameData().getSpectateData().lastMessageNbt.getAllKeys().size();
         String command = GetMessage.getLocalSpectateMessagesCommand(-10, 0);
         return buildMessagesCommonSimpleLocal(size, command, "SpectateMessages");
@@ -268,7 +268,7 @@ public class MessageText {
     }
 
     /**
-     *
+     * [id]
      */
     public static MutableComponent buildSpectateMessageSimple(SpectateMessage spectateMessage, int displayId) {
         if (spectateMessage == null) {

--- a/src/main/java/xiao/battleroyale/event/DelayedEvent.java
+++ b/src/main/java/xiao/battleroyale/event/DelayedEvent.java
@@ -1,0 +1,57 @@
+package xiao.battleroyale.event;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import xiao.battleroyale.BattleRoyale;
+
+import java.util.function.Consumer;
+
+public class DelayedEvent<T> {
+    private final Consumer<T> task;
+    private final T parameter;
+    private int ticksLeft;
+    private final String description;
+
+    /**
+     * 创建一个延迟事件，并立即注册到事件总线
+     * @param task      要执行的函数
+     * @param parameter 传递给函数的参数
+     * @param delay     延迟的tick数
+     * @param description 写入log的说明
+     */
+    public DelayedEvent(Consumer<T> task, T parameter, int delay, String description) {
+        this.task = task;
+        this.parameter = parameter;
+        this.ticksLeft = delay;
+        this.description = description;
+        MinecraftForge.EVENT_BUS.register(this);
+        BattleRoyale.LOGGER.debug("n({}): {}", this.ticksLeft, this.description);
+    }
+
+    /**
+     * 事件监听器：在每个服务器tick结束时触发
+     */
+    @SubscribeEvent
+    public void onServerTick(TickEvent.ServerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) {
+            return;
+        }
+
+        if (--this.ticksLeft == 0) {
+            run();
+            BattleRoyale.LOGGER.debug("Process {}", this.ticksLeft);
+        }
+        if (this.ticksLeft <= 0) {
+            MinecraftForge.EVENT_BUS.unregister(this);
+            BattleRoyale.LOGGER.debug("Unregistered delayedTask: {}", this.description);
+        }
+    }
+
+    /**
+     * 执行任务，不手动try
+     */
+    private void run() {
+        this.task.accept(this.parameter);
+    }
+}

--- a/src/main/java/xiao/battleroyale/event/game/DamageEventHandler.java
+++ b/src/main/java/xiao/battleroyale/event/game/DamageEventHandler.java
@@ -1,5 +1,7 @@
 package xiao.battleroyale.event.game;
 
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
@@ -12,6 +14,7 @@ import xiao.battleroyale.BattleRoyale;
 import xiao.battleroyale.common.game.GameManager;
 import xiao.battleroyale.common.game.spawn.SpawnManager;
 import xiao.battleroyale.common.game.team.GamePlayer;
+import xiao.battleroyale.compat.playerrevive.PlayerRevive;
 import xiao.battleroyale.util.ChatUtils;
 
 /**
@@ -70,6 +73,13 @@ public class DamageEventHandler {
             // 如果双方在同一队伍，且友伤关闭，则取消伤害
             if (attackerGamePlayer.getGameTeamId() == targetGamePlayer.getGameTeamId()) {
                 if (!gameManager.getGameEntry().friendlyFire) {
+                    event.setCanceled(true);
+                }
+            }
+            if (!gameManager.getGameEntry().downFire) {
+                if (damageSource.getEntity() instanceof ServerPlayer attackPlayer
+                        && PlayerRevive.get().isBleeding(attackPlayer)) {
+                    ChatUtils.sendComponentMessageToPlayer(attackPlayer, Component.translatable("battleroyale.message.down_fire_not_enabled").withStyle(ChatFormatting.RED));
                     event.setCanceled(true);
                 }
             }

--- a/src/main/java/xiao/battleroyale/network/GameInfoHandler.java
+++ b/src/main/java/xiao/battleroyale/network/GameInfoHandler.java
@@ -9,6 +9,7 @@ import net.minecraftforge.network.simple.SimpleChannel;
 import org.jetbrains.annotations.NotNull;
 import xiao.battleroyale.BattleRoyale;
 import xiao.battleroyale.network.message.ClientMessageGameInfo;
+import xiao.battleroyale.network.message.ClientMessageSpectateInfo;
 import xiao.battleroyale.network.message.ClientMessageTeamInfo;
 import xiao.battleroyale.network.message.ClientMessageZoneInfo;
 
@@ -16,7 +17,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class GameInfoHandler {
-    private static final String PROTOCOL_VERSION = "1.1";
+    private static final String PROTOCOL_VERSION = "1.2";
 
     public static final SimpleChannel GAME_CHANNEL = NetworkRegistry.newSimpleChannel(
             new ResourceLocation(BattleRoyale.MOD_ID, "game_channel"),
@@ -49,6 +50,14 @@ public class GameInfoHandler {
                 ClientMessageGameInfo.class,
                 (message, buffer) -> message.encode(message, buffer),
                 ClientMessageGameInfo::decode,
+                (message, contextSupplier) -> message.handle(message, contextSupplier),
+                Optional.of(NetworkDirection.PLAY_TO_CLIENT)
+        );
+        GAME_CHANNEL.registerMessage(
+                ID_COUNT.getAndIncrement(),
+                ClientMessageSpectateInfo.class,
+                (message, buffer) -> message.encode(message, buffer),
+                ClientMessageSpectateInfo::decode,
                 (message, contextSupplier) -> message.handle(message, contextSupplier),
                 Optional.of(NetworkDirection.PLAY_TO_CLIENT)
         );

--- a/src/main/java/xiao/battleroyale/network/message/ClientMessageGameInfo.java
+++ b/src/main/java/xiao/battleroyale/network/message/ClientMessageGameInfo.java
@@ -11,15 +11,15 @@ import java.util.function.Supplier;
 
 public class ClientMessageGameInfo implements IMessage<ClientMessageGameInfo> {
 
-    private final @NotNull CompoundTag gameZoneNbt;
+    private final @NotNull CompoundTag gameSyncNbt;
 
-    public ClientMessageGameInfo(CompoundTag gameZoneNbt) {
-        this.gameZoneNbt = gameZoneNbt != null ? gameZoneNbt : new CompoundTag();
+    public ClientMessageGameInfo(CompoundTag gameSyncNbt) {
+        this.gameSyncNbt = gameSyncNbt != null ? gameSyncNbt : new CompoundTag();
     }
 
     @Override
     public void encode(ClientMessageGameInfo message, FriendlyByteBuf buffer) {
-        buffer.writeNbt(message.gameZoneNbt);
+        buffer.writeNbt(message.gameSyncNbt);
     }
 
     public static ClientMessageGameInfo decode(FriendlyByteBuf buffer) {
@@ -31,7 +31,7 @@ public class ClientMessageGameInfo implements IMessage<ClientMessageGameInfo> {
     public void handle(ClientMessageGameInfo message, Supplier<NetworkEvent.Context> contextSupplier) {
         NetworkEvent.Context context = contextSupplier.get();
         context.enqueueWork(() -> {
-            ClientGameDataManager.get().updateGameInfo(message.gameZoneNbt);
+            ClientGameDataManager.get().updateGameInfo(message.gameSyncNbt);
         });
         context.setPacketHandled(true);
     }

--- a/src/main/java/xiao/battleroyale/network/message/ClientMessageSpectateInfo.java
+++ b/src/main/java/xiao/battleroyale/network/message/ClientMessageSpectateInfo.java
@@ -1,0 +1,38 @@
+package xiao.battleroyale.network.message;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.network.NetworkEvent;
+import org.jetbrains.annotations.NotNull;
+import xiao.battleroyale.api.message.IMessage;
+import xiao.battleroyale.client.game.ClientGameDataManager;
+
+import java.util.function.Supplier;
+
+public class ClientMessageSpectateInfo implements IMessage<ClientMessageSpectateInfo> {
+
+    private final @NotNull CompoundTag spectateSyncNbt;
+
+    public ClientMessageSpectateInfo(CompoundTag spectateSyncNbt) {
+        this.spectateSyncNbt = spectateSyncNbt != null ? spectateSyncNbt : new CompoundTag();
+    }
+
+    @Override
+    public void encode(ClientMessageSpectateInfo message, FriendlyByteBuf buffer) {
+        buffer.writeNbt(message.spectateSyncNbt);
+    }
+
+    public static ClientMessageSpectateInfo decode(FriendlyByteBuf buffer) {
+        CompoundTag receivedNbt = buffer.readNbt();
+        return new ClientMessageSpectateInfo(receivedNbt);
+    }
+
+    @Override
+    public void handle(ClientMessageSpectateInfo message, Supplier<NetworkEvent.Context> contextSupplier) {
+        NetworkEvent.Context context = contextSupplier.get();
+        context.enqueueWork(() -> {
+            ClientGameDataManager.get().updateGameSpectateInfo(message.spectateSyncNbt);
+        });
+        context.setPacketHandled(true);
+    }
+}

--- a/src/main/java/xiao/battleroyale/util/ColorUtils.java
+++ b/src/main/java/xiao/battleroyale/util/ColorUtils.java
@@ -1,5 +1,6 @@
 package xiao.battleroyale.util;
 
+import net.minecraft.ChatFormatting;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.DyeColor;
 import org.jetbrains.annotations.NotNull;
@@ -143,5 +144,45 @@ public class ColorUtils {
         }
 
         return generateRandomColors(random, count);
+    }
+
+    /**
+     * 找到与给定RGB颜色最接近的ChatFormatting颜色。
+     * @param rgbColor 24位的RGB颜色值 (0xRRGGBB)。
+     * @return 匹配的ChatFormatting。如果没有合适的，返回ChatFormatting.RESET。
+     */
+    public static ChatFormatting getClosestChatFormatting(int rgbColor) {
+        int minDistance = Integer.MAX_VALUE;
+        ChatFormatting closest = ChatFormatting.RESET;
+
+        for (ChatFormatting formatting : ChatFormatting.values()) {
+            if (formatting.isColor() && formatting.getColor() != null) {
+                int chatColor = formatting.getColor();
+                int distance = getColorDistance(rgbColor, chatColor);
+                if (distance < minDistance) {
+                    minDistance = distance;
+                    closest = formatting;
+                }
+            }
+        }
+        return closest;
+    }
+    public static ChatFormatting getClosestChatFormatting(String colorString) {
+        return getClosestChatFormatting(parseColorToInt(colorString));
+    }
+
+    /**
+     * 计算两个RGB颜色之间的欧几里得距离。
+     */
+    private static int getColorDistance(int color1, int color2) {
+        int r1 = (color1 >> 16) & 0xFF;
+        int g1 = (color1 >> 8) & 0xFF;
+        int b1 = color1 & 0xFF;
+
+        int r2 = (color2 >> 16) & 0xFF;
+        int g2 = (color2 >> 8) & 0xFF;
+        int b2 = color2 & 0xFF;
+
+        return (r2 - r1) * (r2 - r1) + (g2 - g1) * (g2 - g1) + (b2 - b1) * (b2 - b1);
     }
 }

--- a/src/main/java/xiao/battleroyale/util/ColorUtils.java
+++ b/src/main/java/xiao/battleroyale/util/ColorUtils.java
@@ -77,6 +77,25 @@ public class ColorUtils {
     }
 
     /**
+     * 获取颜色#RRGGBB
+     */
+    public static String parseIntToStringRGB(int colorInt) {
+        return String.format("#%06X", colorInt & 0xFFFFFF);
+    }
+
+    /**
+     * 获取颜色#RRGGBBAA
+     */
+    public static String parseIntToStringRGBA(int colorInt) {
+        // AWT的Color.getRGB()返回0xAARRGGBB，需要重新排列
+        int a = (colorInt >> 24) & 0xFF;
+        int r = (colorInt >> 16) & 0xFF;
+        int g = (colorInt >> 8) & 0xFF;
+        int b = colorInt & 0xFF;
+        return String.format("#%02X%02X%02X%02X", r, g, b, a);
+    }
+
+    /**
      * 将字符串表示的颜色的RGB应用到输入颜色
      */
     public static Color changeColorExceptAlpha(Color baseColor, String colorString) {

--- a/src/main/resources/assets/battleroyale/lang/en_us.json
+++ b/src/main/resources/assets/battleroyale/lang/en_us.json
@@ -262,6 +262,7 @@
   "battleroyale.message.switch_gamemode_success": "Switched gamemode",
   "battleroyale.message.switch_gamemode_failed": "Failed to switched gamemode",
   "battleroyale.message.teleport_non_game_player_to_lobby": "Teleported non game player %s to lobby",
+  "battleroyale.message.down_fire_not_enabled": "Downed player damage is not enabled in BattleRoyale gamerule",
 
   "battleroyale.label.alive": "Alive",
 

--- a/src/main/resources/assets/battleroyale/lang/en_us.json
+++ b/src/main/resources/assets/battleroyale/lang/en_us.json
@@ -166,7 +166,8 @@
   "battleroyale.message.lobby_heal": "Lobby heal",
   "battleroyale.message.teleported_to_lobby": "Teleported to lobby",
   "battleroyale.message.failed_lobby_teleport": "Failed to teleport to lobby",
-  "battleroyale.message.not_allow_standing_gameplayer_teleport": "Teleporting is not allowed for standing game players",
+  "battleroyale.message.not_allow_standing_gameplayer_spectate": "Spectating is not allowed for standing game players",
+  "battleroyale.message.not_allow_standing_gameteam_spectate": "Spectating is not allowed for standing game teams",
   "battleroyale.message.selected_bot_config": "Bot config %s: %s",
   "battleroyale.message.selected_gamerule_config": "Gamerule config %s: %s",
   "battleroyale.message.selected_spawn_config": "Spawn config %s: %s",
@@ -262,7 +263,8 @@
   "battleroyale.message.switch_gamemode_success": "Switched gamemode",
   "battleroyale.message.switch_gamemode_failed": "Failed to switched gamemode",
   "battleroyale.message.teleport_non_game_player_to_lobby": "Teleported non game player %s to lobby",
-  "battleroyale.message.down_fire_not_enabled": "Downed player damage is not enabled in BattleRoyale gamerule",
+  "battleroyale.message.down_fire_not_enabled": "Downed player damage is not enabled in BattleRoyale gamerule config",
+  "battleroyale.message.only_game_player_spectate": "Non game player spectate is not enabled in Game config",
 
   "battleroyale.label.alive": "Alive",
 

--- a/src/main/resources/assets/battleroyale/lang/zh_cn.json
+++ b/src/main/resources/assets/battleroyale/lang/zh_cn.json
@@ -262,6 +262,7 @@
   "battleroyale.message.switch_gamemode_success": "已切换游戏模式",
   "battleroyale.message.switch_gamemode_failed": "无法切换游戏模式",
   "battleroyale.message.teleport_non_game_player_to_lobby": "已将非游戏玩家 %s 传送至大厅",
+  "battleroyale.message.down_fire_not_enabled": "大逃杀规则未启用倒地玩家伤害",
 
   "battleroyale.label.alive": "生存",
 

--- a/src/main/resources/assets/battleroyale/lang/zh_cn.json
+++ b/src/main/resources/assets/battleroyale/lang/zh_cn.json
@@ -166,7 +166,8 @@
   "battleroyale.message.lobby_heal": "大厅治疗",
   "battleroyale.message.teleported_to_lobby": "已传送至大厅",
   "battleroyale.message.failed_lobby_teleport": "无法传送至大厅",
-  "battleroyale.message.not_allow_standing_gameplayer_teleport": "当前不允许未被淘汰的游戏玩家传送",
+  "battleroyale.message.not_allow_standing_gameplayer_spectate": "当前不允许未被淘汰的游戏玩家观战",
+  "battleroyale.message.not_allow_standing_gameteam_spectate": "当前不允许未被淘汰的游戏队伍观战",
   "battleroyale.message.selected_bot_config": "人机配置%s: %s",
   "battleroyale.message.selected_gamerule_config": "大逃杀规则配置%s: %s",
   "battleroyale.message.selected_spawn_config": "出生配置%s: %s",
@@ -262,7 +263,8 @@
   "battleroyale.message.switch_gamemode_success": "已切换游戏模式",
   "battleroyale.message.switch_gamemode_failed": "无法切换游戏模式",
   "battleroyale.message.teleport_non_game_player_to_lobby": "已将非游戏玩家 %s 传送至大厅",
-  "battleroyale.message.down_fire_not_enabled": "大逃杀规则未启用倒地玩家伤害",
+  "battleroyale.message.down_fire_not_enabled": "大逃杀规则配置未启用倒地玩家伤害",
+  "battleroyale.message.only_game_player_spectate": "游戏配置未启用非游戏玩家观战",
 
   "battleroyale.label.alive": "生存",
 


### PR DESCRIPTION
Config:
- Gamerule config add many configs
- Add config to not teleport in initGame
- Switch config auto apply first config
- Add spectateEntry to client render config
Game:
- Adjust network protocol to let game spectator render all game teams
- Join game team also build vanilla team
- Adjust default game team color
- Client team info teamId render shader
Other:
- Lobby muteki keeps effect after game and takes effect immediately after reloading config
- Delayed game result, teleport chat message