### PR TITLE
0.3.7-2 Lobby teleport drop inventory

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ mapping_version=1.20.1
 mod_id=battleroyale
 mod_name=Custom BattleRoyale
 mod_license=GPL-3.0 license
-mod_version=0.3.7-1
+mod_version=0.3.7-2
 mod_group_id=xiao.battleroyale
 mod_authors=XiaoColorful

--- a/src/main/java/xiao/battleroyale/api/game/gamerule/BattleroyaleEntryTag.java
+++ b/src/main/java/xiao/battleroyale/api/game/gamerule/BattleroyaleEntryTag.java
@@ -17,9 +17,9 @@ public class BattleroyaleEntryTag extends ConfigEntryTag {
     public static final String LOBBY_MUTEKI = "lobbyMuteki";
     public static final String LOBBY_HEAL = "lobbyHeal";
     public static final String LOBBY_CHANGE_GAMEMODE = "lobbyChangeGamemode";
+    public static final String LOBBY_TELEPORT_CLEAR_INVENTORY = "lobbyTeleportClearInventory";
     public static final String RECORD_STATS = "recordGameStats";
     public static final String AUTO_JOIN = "autoJoinGame";
-    public static final String CLEAR_INVENTORY = "clearInventory";
 
     private BattleroyaleEntryTag() {};
 }

--- a/src/main/java/xiao/battleroyale/api/game/gamerule/BattleroyaleEntryTag.java
+++ b/src/main/java/xiao/battleroyale/api/game/gamerule/BattleroyaleEntryTag.java
@@ -17,6 +17,7 @@ public class BattleroyaleEntryTag extends ConfigEntryTag {
     public static final String LOBBY_MUTEKI = "lobbyMuteki";
     public static final String LOBBY_HEAL = "lobbyHeal";
     public static final String LOBBY_CHANGE_GAMEMODE = "lobbyChangeGamemode";
+    public static final String LOBBY_TELEPORT_DROP_INVENTORY = "lobbyTeleportDropInventory";
     public static final String LOBBY_TELEPORT_CLEAR_INVENTORY = "lobbyTeleportClearInventory";
     public static final String RECORD_STATS = "recordGameStats";
     public static final String AUTO_JOIN = "autoJoinGame";

--- a/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
+++ b/src/main/java/xiao/battleroyale/api/game/gamerule/GameEntryTag.java
@@ -27,6 +27,7 @@ public class GameEntryTag extends ConfigEntryTag {
     public static final String SPECTATE_AFTER_TEAM = "spectateAfterTeamEliminated";
     public static final String SPECTATOR_SEE_ALL_TEAMS = "spectatorSeeAllTeams";
     public static final String TELEPORT_INTERFERER_TO_LOBBY = "teleportInterfererToLobby";
+    public static final String FORCE_ELIMINATION_TELEPORT_TO_LOBBY = "forceEliminationTeleportToLobby";
     public static final String ALLOW_REMAINING_BOT = "allowRemainingBot";
     public static final String KEEP_TEAM_AFTER_GAME = "keepTeamAfterGame";
     public static final String TELEPORT_AFTER_GAME = "teleportAfterGame";

--- a/src/main/java/xiao/battleroyale/api/server/utility/SurvivalEntryTag.java
+++ b/src/main/java/xiao/battleroyale/api/server/utility/SurvivalEntryTag.java
@@ -9,6 +9,8 @@ public class SurvivalEntryTag {
     public static final String LOBBY_DIMENSION = "lobbyDimension";
     public static final String LOBBY_MUTEKI = "lobbyMuteki";
     public static final String LOBBY_HEAL = "lobbyHeal";
+    public static final String DROP_INVENTORY = "dropInventory";
+    public static final String DROP_GAME_ITEM_ONLY = "dropGameItemOnly";
     public static final String CLEAR_INVENTORY = "clearInventory";
     public static final String CLEAR_GAME_ITEM_ONLY = "clearGameItemOnly";
 }

--- a/src/main/java/xiao/battleroyale/common/game/spawn/SpawnManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/spawn/SpawnManager.java
@@ -51,6 +51,7 @@ public class SpawnManager extends AbstractGameManager {
     private boolean lobbyMuteki = true;
     private boolean lobbyHeal = true;
     private boolean changeGamemode = true;
+    private boolean teleportClearInventory = false;
     private IGameSpawner gameSpawner;
 
     @Override
@@ -84,7 +85,7 @@ public class SpawnManager extends AbstractGameManager {
             ChatUtils.sendTranslatableMessageToAllPlayers(serverLevel, "battleroyale.message.missing_gamerule_config");
             return;
         }
-        setLobby(brEntry.lobbyCenterPos, brEntry.lobbyDimension, brEntry.lobbyMuteki, brEntry.lobbyHeal, brEntry.lobbyChangeGamemode);
+        setLobby(brEntry.lobbyCenterPos, brEntry.lobbyDimension, brEntry.lobbyMuteki, brEntry.lobbyHeal, brEntry.lobbyChangeGamemode, brEntry.lobbyTeleportClearInventory);
         if (!isLobbyCreated()) {
             ChatUtils.sendTranslatableMessageToAllPlayers(serverLevel, "battleroyale.message.missing_gamerule_config");
             return;
@@ -182,6 +183,9 @@ public class SpawnManager extends AbstractGameManager {
         if (changeGamemode) {
             player.setGameMode(GameruleManager.get().getGameMode());
         }
+        if (teleportClearInventory) {
+            player.getInventory().clearContent();
+        }
         GameManager gameManager = GameManager.get();
         ServerLevel serverLevel = gameManager.getServerLevel();
         if (serverLevel != null) {
@@ -267,7 +271,7 @@ public class SpawnManager extends AbstractGameManager {
         }
     }
 
-    public boolean setLobby(Vec3 centerPos, Vec3 dimension, boolean shouldMuteki, boolean shouldHeal, boolean changeGamemode) {
+    public boolean setLobby(Vec3 centerPos, Vec3 dimension, boolean shouldMuteki, boolean shouldHeal, boolean changeGamemode, boolean teleportClearInventory) {
         if (GameManager.get().isInGame()) {
             BattleRoyale.LOGGER.debug("GameManager is in game, SpawnManager skipped set lobby");
             return false;
@@ -287,6 +291,7 @@ public class SpawnManager extends AbstractGameManager {
         this.lobbyHeal = shouldHeal;
         this.lobbyDimension = dimension;
         this.changeGamemode = changeGamemode;
+        this.teleportClearInventory = teleportClearInventory;
         BattleRoyale.LOGGER.debug("Successfully set lobby: center{}, dim{}", lobbyPos, lobbyDimension);
         return true;
     }
@@ -303,7 +308,7 @@ public class SpawnManager extends AbstractGameManager {
             BattleRoyale.LOGGER.warn("SpawnManager: radius:{} has negative, reject to apply", radius);
             return false;
         }
-        setLobby(centerPos, new Vec3(radius, radius, radius), this.lobbyMuteki, this.lobbyHeal, this.changeGamemode);
+        setLobby(centerPos, new Vec3(radius, radius, radius), this.lobbyMuteki, this.lobbyHeal, this.changeGamemode, this.teleportClearInventory);
         return true;
     }
 }

--- a/src/main/java/xiao/battleroyale/common/game/spawn/SpawnManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/spawn/SpawnManager.java
@@ -51,6 +51,7 @@ public class SpawnManager extends AbstractGameManager {
     private boolean lobbyMuteki = true;
     private boolean lobbyHeal = true;
     private boolean changeGamemode = true;
+    private boolean teleportDropInventory = false;
     private boolean teleportClearInventory = false;
     private IGameSpawner gameSpawner;
 
@@ -85,7 +86,7 @@ public class SpawnManager extends AbstractGameManager {
             ChatUtils.sendTranslatableMessageToAllPlayers(serverLevel, "battleroyale.message.missing_gamerule_config");
             return;
         }
-        setLobby(brEntry.lobbyCenterPos, brEntry.lobbyDimension, brEntry.lobbyMuteki, brEntry.lobbyHeal, brEntry.lobbyChangeGamemode, brEntry.lobbyTeleportClearInventory);
+        setLobby(brEntry.lobbyCenterPos, brEntry.lobbyDimension, brEntry.lobbyMuteki, brEntry.lobbyHeal, brEntry.lobbyChangeGamemode, brEntry.lobbyTeleportDropInventory, brEntry.lobbyTeleportClearInventory);
         if (!isLobbyCreated()) {
             ChatUtils.sendTranslatableMessageToAllPlayers(serverLevel, "battleroyale.message.missing_gamerule_config");
             return;
@@ -183,6 +184,9 @@ public class SpawnManager extends AbstractGameManager {
         if (changeGamemode) {
             player.setGameMode(GameruleManager.get().getGameMode());
         }
+        if (teleportDropInventory) {
+            player.getInventory().dropAll();
+        }
         if (teleportClearInventory) {
             player.getInventory().clearContent();
         }
@@ -271,7 +275,7 @@ public class SpawnManager extends AbstractGameManager {
         }
     }
 
-    public boolean setLobby(Vec3 centerPos, Vec3 dimension, boolean shouldMuteki, boolean shouldHeal, boolean changeGamemode, boolean teleportClearInventory) {
+    public boolean setLobby(Vec3 centerPos, Vec3 dimension, boolean shouldMuteki, boolean shouldHeal, boolean changeGamemode, boolean teleportDropInventory, boolean teleportClearInventory) {
         if (GameManager.get().isInGame()) {
             BattleRoyale.LOGGER.debug("GameManager is in game, SpawnManager skipped set lobby");
             return false;
@@ -291,6 +295,7 @@ public class SpawnManager extends AbstractGameManager {
         this.lobbyHeal = shouldHeal;
         this.lobbyDimension = dimension;
         this.changeGamemode = changeGamemode;
+        this.teleportDropInventory = teleportDropInventory;
         this.teleportClearInventory = teleportClearInventory;
         BattleRoyale.LOGGER.debug("Successfully set lobby: center{}, dim{}", lobbyPos, lobbyDimension);
         return true;
@@ -308,7 +313,7 @@ public class SpawnManager extends AbstractGameManager {
             BattleRoyale.LOGGER.warn("SpawnManager: radius:{} has negative, reject to apply", radius);
             return false;
         }
-        setLobby(centerPos, new Vec3(radius, radius, radius), this.lobbyMuteki, this.lobbyHeal, this.changeGamemode, this.teleportClearInventory);
+        setLobby(centerPos, new Vec3(radius, radius, radius), this.lobbyMuteki, this.lobbyHeal, this.changeGamemode, this.teleportDropInventory, this.teleportClearInventory);
         return true;
     }
 }

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamExternal.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamExternal.java
@@ -342,6 +342,10 @@ public class TeamExternal {
         ChatUtils.sendComponentMessageToPlayer(requesterPlayer, Component.translatable("battleroyale.message.player_declined_request", teamLeader.getName().getString()).withStyle(ChatFormatting.RED));
     }
 
+    /**
+     * 返回玩家是否还在队伍里
+     * 在游戏中调用该函数只淘汰不离队
+     */
     public static boolean leaveTeam(@NotNull ServerPlayer player) {
         TeamManager teamManager = TeamManager.get();
 
@@ -354,6 +358,7 @@ public class TeamExternal {
 
         teamManager.forceEliminatePlayerFromTeam(player); // 游戏进行时生效，退出即被淘汰，不在游戏运行时则自动跳过
 
+        // ↑在因为forceEliminatePlayerFromTeam而结束游戏后，就不在游戏中
         if (teamManager.removePlayerFromTeam(playerUUID)) { // 不在游戏时生效，手动离开当前队伍
             ChatUtils.sendComponentMessageToPlayer(player, Component.translatable("battleroyale.message.leaved_current_team").withStyle(ChatFormatting.GREEN));
         }
@@ -372,7 +377,7 @@ public class TeamExternal {
         TeamManager teamManager = TeamManager.get();
 
         if (teamManager.teamData.hasStandingGamePlayer(player.getUUID())) { // 游戏进行中，且未被淘汰
-            if (GameManager.get().teleportToLobby(player)) { // 若游戏中传送成功才淘汰
+            if (GameManager.get().teleportToLobby(player)) { // 若成功传送，则淘汰该玩家
                 teamManager.forceEliminatePlayerFromTeam(player); // 强制淘汰
             } else {
                 BattleRoyale.LOGGER.error("Teleport in game player while not has lobby");

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManagement.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManagement.java
@@ -196,11 +196,15 @@ public class TeamManagement {
             BattleRoyale.LOGGER.info("Force eliminated player {} (UUID: {})", player.getName().getString(), player.getUUID());
         }
 
-        ServerLevel serverLevel = GameManager.get().getServerLevel();
+        GameManager gameManager = GameManager.get();
+        ServerLevel serverLevel = gameManager.getServerLevel();
         if (serverLevel != null) {
-            if (!playerEliminatedBefore) {
-                GameManager.get().sendEliminateMessage(gamePlayer);
+            if (!playerEliminatedBefore) { // 从未被淘汰到被淘汰
+                gameManager.sendEliminateMessage(gamePlayer);
                 ChatUtils.sendComponentMessageToAllPlayers(serverLevel, Component.translatable("battleroyale.message.forced_elimination", player.getName()).withStyle(ChatFormatting.RED));
+                if (gameManager.getGameEntry().forceEliminationTeleportToLobby) {
+                    gameManager.teleportToLobby(player); // 不用TeamManager的teleportToLobby
+                }
             } else {
                 BattleRoyale.LOGGER.debug("GamePlayer {} has already been eliminated, TeamManager skipped sending chat message", gamePlayer.getPlayerName());
             }

--- a/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
+++ b/src/main/java/xiao/battleroyale/common/game/team/TeamManager.java
@@ -373,6 +373,10 @@ public class TeamManager extends AbstractGameManager {
         TeamExternal.declineRequest(teamLeader, requesterPlayer);
     }
     // 离开队伍
+    /**
+     * 返回玩家是否还在队伍里
+     * 在游戏中调用该函数只淘汰不离队
+     */
     public boolean leaveTeam(@NotNull ServerPlayer player) {
         return TeamExternal.leaveTeam(player);
     }

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/defaultconfigs/DefaultGamerule.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/defaultconfigs/DefaultGamerule.java
@@ -28,7 +28,7 @@ public class DefaultGamerule {
         BattleroyaleEntry brEntry = new BattleroyaleEntry(OVERWORLD_LEVEL_KEY, 100, 4, true, true,
                 2, 12000, 1,
                 new Vec3(128, -60, 128), new Vec3(10, 10, 10),
-                true, true, true, false,
+                true, true, true, false, false,
                 true, true);
 
         MinecraftEntry mcEntry = new MinecraftEntry(true, false, false,
@@ -47,7 +47,7 @@ public class DefaultGamerule {
         BattleroyaleEntry brEntry = new BattleroyaleEntry(OVERWORLD_LEVEL_KEY, 100, 4, false, false,
                 2, 12000, 1,
                 new Vec3(128, -60, 128), new Vec3(10, 10, 10),
-                true, true, true, false,
+                true, true, true, false, false,
                 true, true);
 
         MinecraftEntry mcEntry = new MinecraftEntry(false, true, false,

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/defaultconfigs/DefaultGamerule.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/defaultconfigs/DefaultGamerule.java
@@ -28,7 +28,8 @@ public class DefaultGamerule {
         BattleroyaleEntry brEntry = new BattleroyaleEntry(OVERWORLD_LEVEL_KEY, 100, 4, true, true,
                 2, 12000, 1,
                 new Vec3(128, -60, 128), new Vec3(10, 10, 10),
-                true, true, true, false, true, true);
+                true, true, true, false,
+                true, true);
 
         MinecraftEntry mcEntry = new MinecraftEntry(true, false, false,
                 true, false, false,
@@ -46,7 +47,8 @@ public class DefaultGamerule {
         BattleroyaleEntry brEntry = new BattleroyaleEntry(OVERWORLD_LEVEL_KEY, 100, 4, false, false,
                 2, 12000, 1,
                 new Vec3(128, -60, 128), new Vec3(10, 10, 10),
-                true, true, true, false, true, true);
+                true, true, true, false,
+                true, true);
 
         MinecraftEntry mcEntry = new MinecraftEntry(false, true, false,
                 true, true, true,

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/defaultconfigs/PubgGamerule.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/defaultconfigs/PubgGamerule.java
@@ -42,7 +42,8 @@ public class PubgGamerule {
         BattleroyaleEntry brEntry = new BattleroyaleEntry(OVERWORLD_LEVEL_KEY, playerTotal, teamSize, bot, bot,
                 2, GAME_TIME, 1,
                 lobbyCenter, lobbyDim,
-                true, true, true, true, true, true);
+                true, true, true, true,
+                true, true);
 
         MinecraftEntry mcEntry = new MinecraftEntry(true, false, true,
                 false, false, false,

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/defaultconfigs/PubgGamerule.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/defaultconfigs/PubgGamerule.java
@@ -42,7 +42,7 @@ public class PubgGamerule {
         BattleroyaleEntry brEntry = new BattleroyaleEntry(OVERWORLD_LEVEL_KEY, playerTotal, teamSize, bot, bot,
                 2, GAME_TIME, 1,
                 lobbyCenter, lobbyDim,
-                true, true, true, true,
+                true, true, true, false, true,
                 true, true);
 
         MinecraftEntry mcEntry = new MinecraftEntry(true, false, true,

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/BattleroyaleEntry.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/BattleroyaleEntry.java
@@ -28,13 +28,14 @@ public class BattleroyaleEntry implements IGameruleEntry, IConfigAppliable {
     public final boolean lobbyMuteki;
     public final boolean lobbyHeal;
     public final boolean lobbyChangeGamemode;
+    public final boolean lobbyTeleportDropInventory;
     public final boolean lobbyTeleportClearInventory;
     public final boolean recordGameStats;
     public final boolean autoJoinGame;
 
     public BattleroyaleEntry(String defaultLevelKey, int playerTotal, int teamSize, boolean aiTeammate, boolean aiEnemy,
                              int requiredTeamToStart, int maxGameTime, int winnerTeamTotal,
-                             Vec3 lobbyCenterPos, Vec3 lobbyDimension, boolean lobbyMuteki, boolean lobbyHeal, boolean lobbyChangeGamemode, boolean lobbyTeleportClearInventory,
+                             Vec3 lobbyCenterPos, Vec3 lobbyDimension, boolean lobbyMuteki, boolean lobbyHeal, boolean lobbyChangeGamemode, boolean lobbyTeleportDropInventory, boolean lobbyTeleportClearInventory,
                              boolean recordGameStats, boolean autoJoinGame) {
         this.defaultLevelKey = defaultLevelKey;
         this.playerTotal = playerTotal;
@@ -49,6 +50,7 @@ public class BattleroyaleEntry implements IGameruleEntry, IConfigAppliable {
         this.lobbyMuteki = lobbyMuteki;
         this.lobbyHeal = lobbyHeal;
         this.lobbyChangeGamemode = lobbyChangeGamemode;
+        this.lobbyTeleportDropInventory = lobbyTeleportDropInventory;
         this.lobbyTeleportClearInventory = lobbyTeleportClearInventory;
         this.recordGameStats = recordGameStats;
         this.autoJoinGame = autoJoinGame;
@@ -75,6 +77,7 @@ public class BattleroyaleEntry implements IGameruleEntry, IConfigAppliable {
         jsonObject.addProperty(BattleroyaleEntryTag.LOBBY_MUTEKI, lobbyMuteki);
         jsonObject.addProperty(BattleroyaleEntryTag.LOBBY_HEAL, lobbyHeal);
         jsonObject.addProperty(BattleroyaleEntryTag.LOBBY_CHANGE_GAMEMODE, lobbyChangeGamemode);
+        jsonObject.addProperty(BattleroyaleEntryTag.LOBBY_TELEPORT_DROP_INVENTORY, lobbyTeleportDropInventory);
         jsonObject.addProperty(BattleroyaleEntryTag.LOBBY_TELEPORT_CLEAR_INVENTORY, lobbyTeleportClearInventory);
         jsonObject.addProperty(BattleroyaleEntryTag.RECORD_STATS, recordGameStats);
         jsonObject.addProperty(BattleroyaleEntryTag.AUTO_JOIN, autoJoinGame);
@@ -99,18 +102,19 @@ public class BattleroyaleEntry implements IGameruleEntry, IConfigAppliable {
         boolean lobbyMuteki = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.LOBBY_MUTEKI, false);
         boolean lobbyHeal = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.LOBBY_HEAL, true);
         boolean lobbyChangeGamemode = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.LOBBY_CHANGE_GAMEMODE, true);
+        boolean lobbyTeleportDropInventory = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.LOBBY_TELEPORT_DROP_INVENTORY, false);
         boolean lobbyTeleportClearInventory = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.LOBBY_TELEPORT_CLEAR_INVENTORY, false);
         boolean recordGameStats = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.RECORD_STATS, true);
         boolean autoJoinGame = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.AUTO_JOIN, false);
         return new BattleroyaleEntry(defaultLevelKey, playerTotal, teamSize, aiTeammate, aiEnemy,
                 requiredTeamToStart, maxGameTime, winnerTeamTotal,
-                lobbyCenterPos, lobbyDimension, lobbyMuteki, lobbyHeal, lobbyChangeGamemode, lobbyTeleportClearInventory,
+                lobbyCenterPos, lobbyDimension, lobbyMuteki, lobbyHeal, lobbyChangeGamemode, lobbyTeleportDropInventory, lobbyTeleportClearInventory,
                 recordGameStats, autoJoinGame);
     }
 
     @Override
     public void applyDefault() {
         GameManager.get().setDefaultLevel(defaultLevelKey);
-        SpawnManager.get().setLobby(lobbyCenterPos, lobbyDimension, lobbyMuteki, lobbyHeal, lobbyChangeGamemode, lobbyTeleportClearInventory);
+        SpawnManager.get().setLobby(lobbyCenterPos, lobbyDimension, lobbyMuteki, lobbyHeal, lobbyChangeGamemode, lobbyTeleportDropInventory, lobbyTeleportClearInventory);
     }
 }

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/BattleroyaleEntry.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/BattleroyaleEntry.java
@@ -28,14 +28,14 @@ public class BattleroyaleEntry implements IGameruleEntry, IConfigAppliable {
     public final boolean lobbyMuteki;
     public final boolean lobbyHeal;
     public final boolean lobbyChangeGamemode;
+    public final boolean lobbyTeleportClearInventory;
     public final boolean recordGameStats;
     public final boolean autoJoinGame;
-    public final boolean clearInventory;
 
     public BattleroyaleEntry(String defaultLevelKey, int playerTotal, int teamSize, boolean aiTeammate, boolean aiEnemy,
                              int requiredTeamToStart, int maxGameTime, int winnerTeamTotal,
-                             Vec3 lobbyCenterPos, Vec3 lobbyDimension, boolean lobbyMuteki, boolean lobbyHeal, boolean lobbyChangeGamemode,
-                             boolean recordGameStats, boolean autoJoinGame, boolean clearInventory) {
+                             Vec3 lobbyCenterPos, Vec3 lobbyDimension, boolean lobbyMuteki, boolean lobbyHeal, boolean lobbyChangeGamemode, boolean lobbyTeleportClearInventory,
+                             boolean recordGameStats, boolean autoJoinGame) {
         this.defaultLevelKey = defaultLevelKey;
         this.playerTotal = playerTotal;
         this.teamSize = teamSize;
@@ -49,9 +49,9 @@ public class BattleroyaleEntry implements IGameruleEntry, IConfigAppliable {
         this.lobbyMuteki = lobbyMuteki;
         this.lobbyHeal = lobbyHeal;
         this.lobbyChangeGamemode = lobbyChangeGamemode;
+        this.lobbyTeleportClearInventory = lobbyTeleportClearInventory;
         this.recordGameStats = recordGameStats;
         this.autoJoinGame = autoJoinGame;
-        this.clearInventory = clearInventory;
     }
 
     @Override
@@ -75,9 +75,9 @@ public class BattleroyaleEntry implements IGameruleEntry, IConfigAppliable {
         jsonObject.addProperty(BattleroyaleEntryTag.LOBBY_MUTEKI, lobbyMuteki);
         jsonObject.addProperty(BattleroyaleEntryTag.LOBBY_HEAL, lobbyHeal);
         jsonObject.addProperty(BattleroyaleEntryTag.LOBBY_CHANGE_GAMEMODE, lobbyChangeGamemode);
+        jsonObject.addProperty(BattleroyaleEntryTag.LOBBY_TELEPORT_CLEAR_INVENTORY, lobbyTeleportClearInventory);
         jsonObject.addProperty(BattleroyaleEntryTag.RECORD_STATS, recordGameStats);
         jsonObject.addProperty(BattleroyaleEntryTag.AUTO_JOIN, autoJoinGame);
-        jsonObject.addProperty(BattleroyaleEntryTag.CLEAR_INVENTORY, clearInventory);
         return jsonObject;
     }
 
@@ -99,18 +99,18 @@ public class BattleroyaleEntry implements IGameruleEntry, IConfigAppliable {
         boolean lobbyMuteki = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.LOBBY_MUTEKI, false);
         boolean lobbyHeal = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.LOBBY_HEAL, true);
         boolean lobbyChangeGamemode = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.LOBBY_CHANGE_GAMEMODE, true);
-        boolean recordGameStats = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.RECORD_STATS, false);
+        boolean lobbyTeleportClearInventory = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.LOBBY_TELEPORT_CLEAR_INVENTORY, false);
+        boolean recordGameStats = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.RECORD_STATS, true);
         boolean autoJoinGame = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.AUTO_JOIN, false);
-        boolean clearInventory = JsonUtils.getJsonBool(jsonObject, BattleroyaleEntryTag.CLEAR_INVENTORY, false);
         return new BattleroyaleEntry(defaultLevelKey, playerTotal, teamSize, aiTeammate, aiEnemy,
                 requiredTeamToStart, maxGameTime, winnerTeamTotal,
-                lobbyCenterPos, lobbyDimension, lobbyMuteki, lobbyHeal, lobbyChangeGamemode,
-                recordGameStats, autoJoinGame, clearInventory);
+                lobbyCenterPos, lobbyDimension, lobbyMuteki, lobbyHeal, lobbyChangeGamemode, lobbyTeleportClearInventory,
+                recordGameStats, autoJoinGame);
     }
 
     @Override
     public void applyDefault() {
         GameManager.get().setDefaultLevel(defaultLevelKey);
-        SpawnManager.get().setLobby(lobbyCenterPos, lobbyDimension, lobbyMuteki, lobbyHeal, lobbyChangeGamemode);
+        SpawnManager.get().setLobby(lobbyCenterPos, lobbyDimension, lobbyMuteki, lobbyHeal, lobbyChangeGamemode, lobbyTeleportClearInventory);
     }
 }

--- a/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
+++ b/src/main/java/xiao/battleroyale/config/common/game/gamerule/type/GameEntry.java
@@ -64,6 +64,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
     public final boolean spectateAfterTeam;
     public final boolean spectatorSeeAllTeams;
     public final boolean teleportInterfererToLobby;
+    public final boolean forceEliminationTeleportToLobby;
 
     public final boolean allowRemainingBot;
     public final boolean keepTeamAfterGame;
@@ -82,7 +83,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
                 20 * 60, 20 * 10, false,
                 true, false, false, DEFAULT_DOWN_DAMAGE, 20,
                 false, false, false, false,
-                false, true, true, true,
+                false, true, true, true, true,
                 true, true, true, false, 0, 0, false,
                 20 * 7, 20 * 5, 20 * 5);
     }
@@ -91,7 +92,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
                      int maxPlayerInvalidTime, int maxBotInvalidTime, boolean removeInvalidTeam,
                      boolean healAllAtStart, boolean friendlyFire, boolean downFire, List<Float> downDamageList, int downDamageFrequency,
                      boolean downShoot, boolean downReload, boolean downFireSelect, boolean downMelee,
-                     boolean onlyGamePlayerSpectate, boolean spectateAfterTeam, boolean spectatorSeeAllTeams, boolean teleportInterfererToLobby,
+                     boolean onlyGamePlayerSpectate, boolean spectateAfterTeam, boolean spectatorSeeAllTeams, boolean teleportInterfererToLobby, boolean forceEliminationTeleportToLobby,
                      boolean allowRemainingBot, boolean keepTeamAfterGame, boolean teleportAfterGame, boolean teleportWinnerAfterGame, int winnerFireworkId, int winnerParticleId, boolean initGameAfterGame,
                      int messageCleanFreq, int messageExpireTime, int messageSyncFreq) {
         this.teleportWhenInitGame = teleportWhenInitGame;
@@ -115,6 +116,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         this.spectateAfterTeam = spectateAfterTeam;
         this.spectatorSeeAllTeams = spectatorSeeAllTeams;
         this.teleportInterfererToLobby = teleportInterfererToLobby;
+        this.forceEliminationTeleportToLobby = forceEliminationTeleportToLobby;
         this.allowRemainingBot = allowRemainingBot;
         this.keepTeamAfterGame = keepTeamAfterGame;
         this.teleportAfterGame = teleportAfterGame;
@@ -160,6 +162,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         jsonObject.addProperty(GameEntryTag.SPECTATE_AFTER_TEAM, spectateAfterTeam);
         jsonObject.addProperty(GameEntryTag.SPECTATOR_SEE_ALL_TEAMS, spectatorSeeAllTeams);
         jsonObject.addProperty(GameEntryTag.TELEPORT_INTERFERER_TO_LOBBY, teleportInterfererToLobby);
+        jsonObject.addProperty(GameEntryTag.FORCE_ELIMINATION_TELEPORT_TO_LOBBY, forceEliminationTeleportToLobby);
 
         jsonObject.addProperty(GameEntryTag.ALLOW_REMAINING_BOT, allowRemainingBot);
         jsonObject.addProperty(GameEntryTag.KEEP_TEAM_AFTER_GAME, keepTeamAfterGame);
@@ -202,6 +205,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
         boolean spectateAfterTeam = JsonUtils.getJsonBool(jsonObject, GameEntryTag.SPECTATE_AFTER_TEAM, true);
         boolean spectatorSeeAllTeams = JsonUtils.getJsonBool(jsonObject, GameEntryTag.SPECTATOR_SEE_ALL_TEAMS, true);
         boolean teleportInterfererToLobby = JsonUtils.getJsonBool(jsonObject, GameEntryTag.TELEPORT_INTERFERER_TO_LOBBY, true);
+        boolean forceEliminationTeleportToLobby = JsonUtils.getJsonBool(jsonObject, GameEntryTag.FORCE_ELIMINATION_TELEPORT_TO_LOBBY, true);
 
         boolean allowRemainingBot = JsonUtils.getJsonBool(jsonObject, GameEntryTag.ALLOW_REMAINING_BOT, false);
         boolean keepTeamAfterGame = JsonUtils.getJsonBool(jsonObject, GameEntryTag.KEEP_TEAM_AFTER_GAME, false);
@@ -219,7 +223,7 @@ public class GameEntry implements IGameruleEntry, IConfigAppliable {
                 maxInvalidTime, maxBotInvalidTime, removeInvalidTeam,
                 healAllAtStart, friendlyFire, downFire, downDamageList, downDamageFrequency,
                 downShoot, downReload, downFireSelect, downMelee,
-                onlyGamePlayerSpectate, spectateAfterTeam, spectatorSeeAllTeams, teleportInterfererToLobby,
+                onlyGamePlayerSpectate, spectateAfterTeam, spectatorSeeAllTeams, teleportInterfererToLobby, forceEliminationTeleportToLobby,
                 allowRemainingBot, keepTeamAfterGame, teleportAfterGame, teleportWinnerAfterGame, winnerFireworkId, winnerParticleId, initGameAfterGame,
                 messageCleanFreq, messageExpireTime, messageSyncFreq);
     }

--- a/src/main/java/xiao/battleroyale/config/common/server/utility/defaultconfigs/DefaultUtility.java
+++ b/src/main/java/xiao/battleroyale/config/common/server/utility/defaultconfigs/DefaultUtility.java
@@ -25,7 +25,7 @@ public class DefaultUtility {
     private static JsonObject generateDefaultUtilityConfig0() {
         SurvivalEntry survivalEntry = new SurvivalEntry(OVERWORLD_LEVEL_KEY, false,
                 new Vec3(0, 70, 0), new Vec3(8, 160, 8), false, false,
-                true, true);
+                true, true, true, true);
 
         UtilityConfig utilityConfig = new UtilityConfig(0, "Overworld Survival", "#FFFFFF", true, survivalEntry);
         return utilityConfig.toJson();

--- a/src/main/java/xiao/battleroyale/config/common/server/utility/type/SurvivalEntry.java
+++ b/src/main/java/xiao/battleroyale/config/common/server/utility/type/SurvivalEntry.java
@@ -21,16 +21,21 @@ public class SurvivalEntry implements IUtilityEntry, IConfigAppliable {
     public final Vec3 lobbyDimension;
     public final boolean lobbyMuteki;
     public final boolean lobbyHeal;
+    public final boolean dropInventory;
+    public final boolean dropGameItemOnly;
     public final boolean clearInventory;
     public final boolean clearGameItemOnly;
 
-    public SurvivalEntry(String levelKey, boolean allowGamePlayerTeleport, Vec3 lobbyCenter, Vec3 lobbyDimension, boolean lobbyMuteki, boolean lobbyHeal, boolean clearInventory, boolean clearGameItemOnly) {
+    public SurvivalEntry(String levelKey, boolean allowGamePlayerTeleport, Vec3 lobbyCenter, Vec3 lobbyDimension, boolean lobbyMuteki, boolean lobbyHeal,
+                         boolean dropInventory, boolean dropGameItemOnly, boolean clearInventory, boolean clearGameItemOnly) {
         this.levelKey = levelKey;
         this.allowGamePlayerTeleport = allowGamePlayerTeleport;
         this.lobbyCenter = lobbyCenter;
         this.lobbyDimension = lobbyDimension;
         this.lobbyMuteki = lobbyMuteki;
         this.lobbyHeal = lobbyHeal;
+        this.dropInventory = dropInventory;
+        this.dropGameItemOnly = dropGameItemOnly;
         this.clearInventory = clearInventory;
         this.clearGameItemOnly = clearGameItemOnly;
     }
@@ -64,17 +69,20 @@ public class SurvivalEntry implements IUtilityEntry, IConfigAppliable {
         }
         boolean lobbyMuteki = JsonUtils.getJsonBool(survivalLobbyObject, SurvivalEntryTag.LOBBY_MUTEKI, false);
         boolean lobbyHeal = JsonUtils.getJsonBool(survivalLobbyObject, SurvivalEntryTag.LOBBY_HEAL, false);
+        boolean dropInventory = JsonUtils.getJsonBool(survivalLobbyObject, SurvivalEntryTag.DROP_INVENTORY, true);
+        boolean dropGameItemOnly = JsonUtils.getJsonBool(survivalLobbyObject, SurvivalEntryTag.DROP_GAME_ITEM_ONLY, true);
         boolean clearInventory = JsonUtils.getJsonBool(survivalLobbyObject, SurvivalEntryTag.CLEAR_INVENTORY, true);
         boolean clearGameItemOnly = JsonUtils.getJsonBool(survivalLobbyObject, SurvivalEntryTag.CLEAR_GAME_ITEM_ONLY, true);
 
-        return new SurvivalEntry(levelDimension, allowGamePlayerTeleport, lobbyCenter, lobbyDimension, lobbyMuteki, lobbyHeal, clearInventory, clearGameItemOnly);
+        return new SurvivalEntry(levelDimension, allowGamePlayerTeleport, lobbyCenter, lobbyDimension, lobbyMuteki, lobbyHeal,
+                dropInventory, dropGameItemOnly, clearInventory, clearGameItemOnly);
     }
 
     @Override
     public void applyDefault() {
         SurvivalLobby.get().setLobby(levelKey, allowGamePlayerTeleport,
                 lobbyCenter, lobbyDimension, lobbyMuteki, lobbyHeal,
-                clearInventory, clearGameItemOnly);
+                dropInventory, dropGameItemOnly, clearInventory, clearGameItemOnly);
     }
 
     @NotNull
@@ -86,6 +94,8 @@ public class SurvivalEntry implements IUtilityEntry, IConfigAppliable {
         jsonObject.addProperty(SurvivalEntryTag.LOBBY_DIMENSION, StringUtils.vectorToString(lobbyDimension));
         jsonObject.addProperty(SurvivalEntryTag.LOBBY_MUTEKI, lobbyMuteki);
         jsonObject.addProperty(SurvivalEntryTag.LOBBY_HEAL, lobbyHeal);
+        jsonObject.addProperty(SurvivalEntryTag.DROP_INVENTORY, dropInventory);
+        jsonObject.addProperty(SurvivalEntryTag.DROP_GAME_ITEM_ONLY, dropGameItemOnly);
         jsonObject.addProperty(SurvivalEntryTag.CLEAR_INVENTORY, clearInventory);
         jsonObject.addProperty(SurvivalEntryTag.CLEAR_GAME_ITEM_ONLY, clearGameItemOnly);
         return jsonObject;


### PR DESCRIPTION
Update lobby teleport related config in gamerule & utility config to enable/disable:
- Teleport to game lobby clear inventory
- Drop inventory before teleport to game lobby
- Leave team (force elimination) do lobby teleport
- Teleport to survival lobby drop inventory
- Only drop loot item